### PR TITLE
revise api_key to use varbinary

### DIFF
--- a/backend/migrations/20200617193248-case-senitive-apikey.sql
+++ b/backend/migrations/20200617193248-case-senitive-apikey.sql
@@ -1,0 +1,4 @@
+-- +migrate Up
+ALTER TABLE api_keys MODIFY access_key VARBINARY(255) NOT NULL;
+-- +migrate Down
+ALTER TABLE api_keys MODIFY access_key VARCHAR(255) NOT NULL;

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -25,7 +25,7 @@ DROP TABLE IF EXISTS `api_keys`;
 CREATE TABLE `api_keys` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) NOT NULL,
-  `access_key` varchar(255) NOT NULL,
+  `access_key` varbinary(255) NOT NULL,
   `secret_key` varbinary(255) NOT NULL,
   `last_auth` timestamp NULL DEFAULT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -302,7 +302,7 @@ CREATE TABLE `users` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-04-03 15:14:28
+-- Dump completed on 2020-06-17 19:38:32
 -- MySQL dump 10.13  Distrib 8.0.17, for Linux (x86_64)
 --
 -- Host: localhost    Database: migrate_db
@@ -326,7 +326,7 @@ CREATE TABLE `users` (
 
 LOCK TABLES `gorp_migrations` WRITE;
 /*!40000 ALTER TABLE `gorp_migrations` DISABLE KEYS */;
-INSERT INTO `gorp_migrations` VALUES ('20190705190058-create-users-table.sql','2020-04-03 15:14:21'),('20190708185420-create-operations-table.sql','2020-04-03 15:14:21'),('20190708185427-create-events-table.sql','2020-04-03 15:14:22'),('20190708185432-create-evidence-table.sql','2020-04-03 15:14:22'),('20190708185441-create-evidence-event-map-table.sql','2020-04-03 15:14:22'),('20190716190100-create-user-operation-map-table.sql','2020-04-03 15:14:22'),('20190722193434-create-tags-table.sql','2020-04-03 15:14:22'),('20190722193937-create-tag-event-map.sql','2020-04-03 15:14:22'),('20190909183500-add-short-name-to-users-table.sql','2020-04-03 15:14:22'),('20190909190416-add-short-name-index.sql','2020-04-03 15:14:22'),('20190926205116-evidence-name.sql','2020-04-03 15:14:23'),('20190930173342-add-saved-searches.sql','2020-04-03 15:14:23'),('20191001182541-evidence-tags.sql','2020-04-03 15:14:23'),('20191008005212-add-uuid-to-events-evidence.sql','2020-04-03 15:14:23'),('20191015235306-add-slug-to-operations.sql','2020-04-03 15:14:23'),('20191018172105-modular-auth.sql','2020-04-03 15:14:24'),('20191023170906-codeblock.sql','2020-04-03 15:14:24'),('20191101185207-replace-events-with-findings.sql','2020-04-03 15:14:25'),('20191114211948-add-operation-to-tags.sql','2020-04-03 15:14:25'),('20191205182830-create-api-keys-table.sql','2020-04-03 15:14:25'),('20191213222629-users-with-email.sql','2020-04-03 15:14:25'),('20200103194053-rename-short-name-to-slug.sql','2020-04-03 15:14:25'),('20200104013804-rework-ashirt-auth.sql','2020-04-03 15:14:26'),('20200116070736-add-admin-flag.sql','2020-04-03 15:14:26'),('20200130175541-fix-color-truncation.sql','2020-04-03 15:14:26'),('20200205200208-disable-user-support.sql','2020-04-03 15:14:26'),('20200215015330-optional-user-id.sql','2020-04-03 15:14:26'),('20200221195107-deletable-user.sql','2020-04-03 15:14:27'),('20200303215004-move-last-login.sql','2020-04-03 15:14:27'),('20200306221628-add-explicit-headless.sql','2020-04-03 15:14:27'),('20200331155258-finding-status.sql','2020-04-03 15:14:28');
+INSERT INTO `gorp_migrations` VALUES ('20190705190058-create-users-table.sql','2020-06-17 19:38:26'),('20190708185420-create-operations-table.sql','2020-06-17 19:38:26'),('20190708185427-create-events-table.sql','2020-06-17 19:38:26'),('20190708185432-create-evidence-table.sql','2020-06-17 19:38:26'),('20190708185441-create-evidence-event-map-table.sql','2020-06-17 19:38:26'),('20190716190100-create-user-operation-map-table.sql','2020-06-17 19:38:26'),('20190722193434-create-tags-table.sql','2020-06-17 19:38:26'),('20190722193937-create-tag-event-map.sql','2020-06-17 19:38:26'),('20190909183500-add-short-name-to-users-table.sql','2020-06-17 19:38:26'),('20190909190416-add-short-name-index.sql','2020-06-17 19:38:27'),('20190926205116-evidence-name.sql','2020-06-17 19:38:27'),('20190930173342-add-saved-searches.sql','2020-06-17 19:38:27'),('20191001182541-evidence-tags.sql','2020-06-17 19:38:27'),('20191008005212-add-uuid-to-events-evidence.sql','2020-06-17 19:38:27'),('20191015235306-add-slug-to-operations.sql','2020-06-17 19:38:28'),('20191018172105-modular-auth.sql','2020-06-17 19:38:28'),('20191023170906-codeblock.sql','2020-06-17 19:38:28'),('20191101185207-replace-events-with-findings.sql','2020-06-17 19:38:29'),('20191114211948-add-operation-to-tags.sql','2020-06-17 19:38:29'),('20191205182830-create-api-keys-table.sql','2020-06-17 19:38:29'),('20191213222629-users-with-email.sql','2020-06-17 19:38:29'),('20200103194053-rename-short-name-to-slug.sql','2020-06-17 19:38:29'),('20200104013804-rework-ashirt-auth.sql','2020-06-17 19:38:30'),('20200116070736-add-admin-flag.sql','2020-06-17 19:38:30'),('20200130175541-fix-color-truncation.sql','2020-06-17 19:38:30'),('20200205200208-disable-user-support.sql','2020-06-17 19:38:30'),('20200215015330-optional-user-id.sql','2020-06-17 19:38:31'),('20200221195107-deletable-user.sql','2020-06-17 19:38:31'),('20200303215004-move-last-login.sql','2020-06-17 19:38:31'),('20200306221628-add-explicit-headless.sql','2020-06-17 19:38:31'),('20200331155258-finding-status.sql','2020-06-17 19:38:31'),('20200617193248-case-senitive-apikey.sql','2020-06-17 19:38:32');
 /*!40000 ALTER TABLE `gorp_migrations` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
@@ -339,4 +339,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-04-03 15:14:29
+-- Dump completed on 2020-06-17 19:38:33


### PR DESCRIPTION
This PR addresses an issue with api key identification. Specifically, when an API key is generated, it is a base64 encoded value (of random characters). Base64 usually, and in this case, uses both a-z and A-Z, meaning that the resulting string is _case sensitive_. In contrast, mysql uses a default collation that treats strings in a _case insensitive_ way. The result is that our base 64 api key actually ends up being an effective base 38 api key.

This fix resolves this issue by changing the type of the column to varbinary, which will compare keys based on their byte values, rather than their "human values."

Note: This only affects the access key. The secret key was already varbinary, and thus unaffected.