### PR TITLE
Bugfix: Restrict help menu to only open when over the page body

### DIFF
--- a/frontend/src/components/help/index.tsx
+++ b/frontend/src/components/help/index.tsx
@@ -61,6 +61,11 @@ export type KeyboardShortcut = {
   description: string
 }
 
+const commonKeyboardShortcuts = [
+  { keys: ["?"], description: "Open this help menu" },
+  { keys: ["Escape"], description: "Close this window" },
+]
+
 export const HelpModal = (props: {
   preamble?: string,
   shortcuts?: Array<KeyboardShortcut>,
@@ -81,7 +86,10 @@ export const HelpModal = (props: {
       {!props.shortcuts ? null :
         <div className={cx('shortcuts')}>
           <h1>Keyboard Shortcuts</h1>
-          {props.shortcuts.map(shortcut => <KeyboardShortcutKey key={shortcut.keys[0]} shortcut={shortcut} />)}
+          {props.shortcuts
+            .concat(commonKeyboardShortcuts)
+            .map(shortcut => <KeyboardShortcutKey key={shortcut.keys[0]} shortcut={shortcut} />)
+          }
         </div>
       }
       <Button primary onClick={props.onRequestClose}>Close</Button>


### PR DESCRIPTION
Prevents the help menu from opening while in a textbox
Addresses Issue: #11 

## Details

### Front End Changes

* Revises help menu's onKeyDown to only function when the event target is both non-null and acting on the document body.
* Adds "?" and "escape" keys to the help menu, showing the menu how they can open and close the help menu from the keyboard.

## Meeting License Requirements

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.