### PR TITLE
encode query component

### DIFF
--- a/frontend/src/pages/operation_show/evidence_list/index.tsx
+++ b/frontend/src/pages/operation_show/evidence_list/index.tsx
@@ -32,7 +32,7 @@ export default (props: RouteComponentProps<{slug: string}>) => {
 
   const navigate = (view: ViewName, query: string) => {
     let path = `/operations/${slug}/${view}`
-    if (query != '') path += `?q=${query}`
+    if (query != '') path += `?q=${encodeURIComponent(query)}`
     props.history.push(path)
   }
 

--- a/frontend/src/pages/operation_show/finding_list/index.tsx
+++ b/frontend/src/pages/operation_show/finding_list/index.tsx
@@ -23,7 +23,7 @@ export default (props: RouteComponentProps<{slug: string}>) => {
 
   const navigate = (view: ViewName, query: string) => {
     let path = `/operations/${slug}/${view}`
-    if (query != '') path += `?q=${query}`
+    if (query != '') path += `?q=${encodeURIComponent(query)}`
     props.history.push(path)
   }
 


### PR DESCRIPTION
Corrects an issue with queries where certain characters (e.g. `#`) could not be filtered on appropriately, 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
