### PR TITLE
adds api endpoint for additional evidence details

### DIFF
--- a/backend/server/api.go
+++ b/backend/server/api.go
@@ -151,10 +151,16 @@ func bindAPIRoutes(r chi.Router, db *database.Connection, contentStore contentst
 
 	route(r, "GET", "/operations/{operation_slug}/evidence", jsonHandler(func(r *http.Request) (interface{}, error) {
 		dr := dissectJSONRequest(r)
-		tlq, _ := helpers.ParseTimelineQuery(dr.FromQuery("q").AsString())
+		tlq, err := helpers.ParseTimelineQuery(dr.FromQuery("query").AsString())
+		if err != nil {
+			return nil, err
+		}
 		i := services.ListEvidenceForOperationInput{
 			OperationSlug: dr.FromURL("operation_slug").Required().AsString(),
 			Filters:       tlq,
+		}
+		if dr.Error != nil {
+			return nil, dr.Error
 		}
 		return services.ListEvidenceForOperation(r.Context(), db, i)
 	}))

--- a/backend/server/api.go
+++ b/backend/server/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/theparanoids/ashirt-server/backend/contentstore"
 	"github.com/theparanoids/ashirt-server/backend/database"
 	"github.com/theparanoids/ashirt-server/backend/dtos"
+	"github.com/theparanoids/ashirt-server/backend/helpers"
 	"github.com/theparanoids/ashirt-server/backend/logging"
 	"github.com/theparanoids/ashirt-server/backend/server/middleware"
 	"github.com/theparanoids/ashirt-server/backend/services"
@@ -146,6 +147,16 @@ func bindAPIRoutes(r chi.Router, db *database.Connection, contentStore contentst
 			OperationSlug: dr.FromURL("operation_slug").Required().AsString(),
 		}
 		return services.ListTagsForOperation(r.Context(), db, i)
+	}))
+
+	route(r, "GET", "/operations/{operation_slug}/evidence", jsonHandler(func(r *http.Request) (interface{}, error) {
+		dr := dissectJSONRequest(r)
+		tlq, _ := helpers.ParseTimelineQuery(dr.FromQuery("q").AsString())
+		i := services.ListEvidenceForOperationInput{
+			OperationSlug: dr.FromURL("operation_slug").Required().AsString(),
+			Filters:       tlq,
+		}
+		return services.ListEvidenceForOperation(r.Context(), db, i)
 	}))
 
 	route(r, "POST", "/operations/{operation_slug}/tags", jsonHandler(func(r *http.Request) (interface{}, error) {


### PR DESCRIPTION
While creating a service worker, I found myself needing more details about the evidence that was being created, like tags and the operator. 


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.