### PR TITLE
Tn/add api to web

### DIFF
--- a/backend/bin/web/web.go
+++ b/backend/bin/web/web.go
@@ -101,6 +101,12 @@ func main() {
 		)
 	})
 
+	r.Route("/api", func(r chi.Router) {
+		server.API(r,
+			db, contentStore, logger,
+		)
+	})
+
 	logger.Log("msg", "starting Web server", "port", config.Port())
 	serveErr := http.ListenAndServe(":"+config.Port(), r)
 	logging.Fatal(logger, "msg", "server shutting down", "err", serveErr)

--- a/backend/server/api.go
+++ b/backend/server/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ashirt-ops/ashirt-server/backend"
 	"github.com/ashirt-ops/ashirt-server/backend/contentstore"
 	"github.com/ashirt-ops/ashirt-server/backend/database"
+	"github.com/ashirt-ops/ashirt-server/backend/dtos"
 	"github.com/ashirt-ops/ashirt-server/backend/logging"
 	"github.com/ashirt-ops/ashirt-server/backend/server/middleware"
 	"github.com/ashirt-ops/ashirt-server/backend/services"
@@ -30,6 +31,10 @@ func API(r chi.Router, db *database.Connection, contentStore contentstore.Store,
 }
 
 func bindAPIRoutes(r chi.Router, db *database.Connection, contentStore contentstore.Store) {
+	route(r, "GET", "/checkconnection", jsonHandler(func(r *http.Request) (interface{}, error) {
+		return dtos.CheckConnection{Ok: true}, nil
+	}))
+
 	route(r, "GET", "/operations/{operation_slug}/evidence/{evidence_uuid}/{type:media|preview}", mediaHandler(func(r *http.Request) (io.Reader, error) {
 		dr := dissectNoBodyRequest(r)
 		i := services.ReadEvidenceInput{

--- a/backend/server/shared_routes.go
+++ b/backend/server/shared_routes.go
@@ -1,0 +1,59 @@
+// Copyright 2023, Yahoo Inc.
+// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
+
+package server
+
+import (
+	"net/http"
+
+	"github.com/ashirt-ops/ashirt-server/backend/contentstore"
+	"github.com/ashirt-ops/ashirt-server/backend/database"
+	"github.com/ashirt-ops/ashirt-server/backend/dtos"
+	"github.com/ashirt-ops/ashirt-server/backend/server/middleware"
+	"github.com/ashirt-ops/ashirt-server/backend/services"
+	"github.com/go-chi/chi/v5"
+)
+
+func bindSharedRoutes(r chi.Router, db *database.Connection, contentStore contentstore.Store) {
+	route(r, "GET", "/checkconnection", jsonHandler(func(r *http.Request) (interface{}, error) {
+		return dtos.CheckConnection{Ok: true}, nil
+	}))
+
+	route(r, "GET", "/operations", jsonHandler(func(r *http.Request) (interface{}, error) {
+		return services.ListOperations(r.Context(), db)
+	}))
+
+	route(r, "POST", "/operations", jsonHandler(func(r *http.Request) (interface{}, error) {
+		dr := dissectJSONRequest(r)
+		i := services.CreateOperationInput{
+			Slug:    dr.FromBody("slug").Required().AsString(),
+			Name:    dr.FromBody("name").Required().AsString(),
+			OwnerID: middleware.UserID(r.Context()),
+		}
+		if dr.Error != nil {
+			return nil, dr.Error
+		}
+		return services.CreateOperation(r.Context(), db, i)
+	}))
+
+	route(r, "GET", "/operations/{operation_slug}/tags", jsonHandler(func(r *http.Request) (interface{}, error) {
+		dr := dissectJSONRequest(r)
+		i := services.ListTagsForOperationInput{
+			OperationSlug: dr.FromURL("operation_slug").Required().AsString(),
+		}
+		return services.ListTagsForOperation(r.Context(), db, i)
+	}))
+
+	route(r, "POST", "/operations/{operation_slug}/tags", jsonHandler(func(r *http.Request) (interface{}, error) {
+		dr := dissectJSONRequest(r)
+		i := services.CreateTagInput{
+			Name:          dr.FromBody("name").Required().AsString(),
+			ColorName:     dr.FromBody("colorName").AsString(),
+			OperationSlug: dr.FromURL("operation_slug").Required().AsString(),
+		}
+		if dr.Error != nil {
+			return nil, dr.Error
+		}
+		return services.CreateTag(r.Context(), db, i)
+	}))
+}

--- a/backend/server/shared_routes.go
+++ b/backend/server/shared_routes.go
@@ -8,17 +8,12 @@ import (
 
 	"github.com/ashirt-ops/ashirt-server/backend/contentstore"
 	"github.com/ashirt-ops/ashirt-server/backend/database"
-	"github.com/ashirt-ops/ashirt-server/backend/dtos"
 	"github.com/ashirt-ops/ashirt-server/backend/server/middleware"
 	"github.com/ashirt-ops/ashirt-server/backend/services"
 	"github.com/go-chi/chi/v5"
 )
 
 func bindSharedRoutes(r chi.Router, db *database.Connection, contentStore contentstore.Store) {
-	route(r, "GET", "/checkconnection", jsonHandler(func(r *http.Request) (interface{}, error) {
-		return dtos.CheckConnection{Ok: true}, nil
-	}))
-
 	route(r, "GET", "/operations", jsonHandler(func(r *http.Request) (interface{}, error) {
 		return services.ListOperations(r.Context(), db)
 	}))

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,6 +1,6 @@
 version: "3"
 services:
-  ashirt-private-service:
+  ashirt-service:
     build:
       context: .
       dockerfile: Dockerfile.prod.web
@@ -23,21 +23,6 @@ services:
       AUTH_SERVICES: ashirt
       DB_URI: dev-user:dev-user-password@tcp(db:3306)/dev-db
 
-
-  ashirt-public-service:
-    build:
-      context: .
-      dockerfile: Dockerfile.prod.api
-    ports:
-      - 8001:8000
-    restart: on-failure
-    environment:
-      APP_IMGSTORE_BUCKET_NAME: ""
-      APP_IMGSTORE_REGION: ""
-      APP_PORT: 8000
-      DB_URI: dev-user:dev-user-password@tcp(db:3306)/dev-db
-
-
   frontend:
     build:
       context: .
@@ -46,7 +31,7 @@ services:
       - 8080:8080
     environment:
       NGINX_PORT: 8080
-      WEB_URL: http://ashirt-private-service:8000
+      WEB_URL: http://ashirt-service:8000
 
   db:
     image: mysql:8.0

--- a/frontend/default.conf.template
+++ b/frontend/default.conf.template
@@ -15,6 +15,10 @@ server {
       proxy_pass ${WEB_URL};
     }
 
+    location /api {
+      proxy_pass ${WEB_URL};
+    }
+
     location /assets {
       root     /usr/share/nginx/html;
       try_files $uri $uri/;

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -75,6 +75,7 @@ module.exports = (env, argv) => ({
     historyApiFallback: true,
     proxy: {
       '/web': {target: process.env.WEB_BACKEND_ORIGIN},
+      '/api': {target: process.env.WEB_BACKEND_ORIGIN},
     },
     devMiddleware: {
       publicPath: "/assets/"


### PR DESCRIPTION
Based on John's feedback about not adding web functionality to the API, it was much easier for me to create a new branch than to correct my old [one](https://github.com/ashirt-ops/ashirt-server/pull/892). This branch ensures the shared routes only contains routes that are identical between API and web ~~(with the exception of `checkconnection`)~~ AND includes @jkennedyvz's config [changes](https://github.com/ashirt-ops/ashirt-server/pull/897). If this is what you guys prefer then we can close #892 and #897 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
