### PR TITLE
allow searching for multiple meta terms

### DIFF
--- a/backend/services/evidence.go
+++ b/backend/services/evidence.go
@@ -457,7 +457,7 @@ func buildListEvidenceWhereClause(sb sq.SelectBuilder, operationID int64, filter
 			metadataSubquery = metadataSubquery.Where(sq.Like{"body": "%" + text + "%"})
 		}
 		if q, v, e := metadataSubquery.ToSql(); e == nil {
-			sb = sb.Where("evidence.id IN ("+q+")", v)
+			sb = sb.Where("evidence.id IN ("+q+")", v...)
 		}
 	}
 

--- a/backend/services/evidence_internal_test.go
+++ b/backend/services/evidence_internal_test.go
@@ -46,10 +46,7 @@ func TestBuildListEvidenceWhereClause(t *testing.T) {
 	meta := []string{"one", "two"}
 	metaBuilder := buildListEvidenceWhereClause(base, opID, helpers.TimelineFilters{Metadata: meta})
 	require.Equal(t, " WHERE evidence.operation_id = ? AND evidence.id IN (SELECT evidence_id FROM evidence_metadata WHERE body LIKE ? AND body LIKE ?)", toWhere(metaBuilder))
-	require.Equal(t, []interface{}{opID, []interface{}{
-		"%" + meta[0] + "%",
-		"%" + meta[1] + "%",
-	}}, toWhereValues(metaBuilder))
+	require.Equal(t, []interface{}{opID, "%" + meta[0] + "%", "%" + meta[1] + "%"}, toWhereValues(metaBuilder))
 
 	start, end := time.Now(), time.Now().Add(5*time.Second)
 	singleDate := filter.DateValues{


### PR DESCRIPTION
fixes bug where searching for multiple meta terms returned an error

If you searched for two meta terms, the sql that this function generated looks like this:
```sql
WHERE  evidence.operation_id = ?
       AND evidence.id IN (SELECT evidence_id
                           FROM   evidence_metadata
                           WHERE  body LIKE ?
                                  AND body LIKE ?)
```
which includes three parameter placeholders. However, sqlx was complaining because the last two params were passed along as a slice (ie `[4, ["%13%", "%seed_juice%"]]`) so it counted only two values, which didn't line up with three placeholders. Destructuring the `body Like` params solves the problem `[4, "%13%", "%seed_juice%"]` because now there are an equal number of params and placeholders.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
