### PR TITLE
fix operation edit bug

### DIFF
--- a/frontend/src/pages/operation_edit/operation_editor/index.tsx
+++ b/frontend/src/pages/operation_edit/operation_editor/index.tsx
@@ -16,7 +16,7 @@ const EditForm = (props: {
   const nameField = useFormField(props.name)
   React.useEffect(() => {
     nameField.onChange(props.name)
-  }, [props.name, nameField])
+  }, [props.name])
 
   const formComponentProps = useForm({
     fields: [nameField],


### PR DESCRIPTION
fixes a bug (that's existed for about 9 months) where if a user tries to edit an operation name, they are unable to enter new characters

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
