### PR TITLE
feat: ensure same url for full screen image

### DIFF
--- a/backend/server/web.go
+++ b/backend/server/web.go
@@ -509,6 +509,7 @@ func bindWebRoutes(r chi.Router, db *database.Connection, contentStore contentst
 			if err != nil {
 				return nil, backend.WrapError("Unable to send s3 URL", err)
 			}
+			fmt.Printf("sending s3 URL %+v\n", urlData)
 			return bytes.NewReader(jsonifiedData), nil
 		}
 		if i.LoadPreview {

--- a/backend/server/web.go
+++ b/backend/server/web.go
@@ -509,7 +509,6 @@ func bindWebRoutes(r chi.Router, db *database.Connection, contentStore contentst
 			if err != nil {
 				return nil, backend.WrapError("Unable to send s3 URL", err)
 			}
-			fmt.Printf("sending s3 URL %+v\n", urlData)
 			return bytes.NewReader(jsonifiedData), nil
 		}
 		if i.LoadPreview {

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -18,7 +18,7 @@ function getComponent(evidenceType: SupportedEvidenceType) {
     case 'codeblock':
       return EvidenceCodeblock
     case 'image':
-      return EvidenceImage
+      return MemoizedEvidenceImage
     case 'terminal-recording':
       return EvidenceTerminalRecording
     case 'http-request-cycle':
@@ -108,6 +108,12 @@ const EvidenceImage = (props: EvidenceProps) => {
   }
   return <img src={url} />
 }
+
+const sameURL = (prevProps: EvidenceProps, nextProps: EvidenceProps) => {
+  return prevProps?.preSavedS3UrlData?.url === nextProps?.preSavedS3UrlData?.url;
+};
+
+const MemoizedEvidenceImage = React.memo(EvidenceImage, sameURL);
 
 const EvidenceEvent = (_props: EvidenceProps) => {
   return <div className={cx('event')}></div>

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -81,19 +81,11 @@ const EvidenceCodeblock = (props: EvidenceProps) => {
 
 const EvidenceImage = (props: EvidenceProps) => {
   const { imgDataSetter, imgData, activeEvidence } = useEvidenceContext()
-
-
-  console.log("---------------------")
-  console.log("viewHint in same URL", props?.viewHint)
-  console.log("EvidenceImage props", imgData?.url.slice(-3))
-  console.log("imgData:", imgData)
-  console.log("sendUrl", props.useS3Url)
   let url = `/web/operations/${props.operationSlug}/evidence/${props.evidenceUuid}/media`
 
   if (imgData && props.useS3Url && isAfter(new Date(imgData.expirationTime), new Date()) && (props.evidenceUuid === activeEvidence?.uuid)) {
     url = imgData.url
   } else if (props.useS3Url) {
-    console.log("getting s3 url")
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const wiredUrl = useWiredData<UrlData>(React.useCallback(() => getEvidenceAsUrlData({
       operationSlug: props.operationSlug,
@@ -105,9 +97,6 @@ const EvidenceImage = (props: EvidenceProps) => {
       url = s3url.url
     })
   }
-
-  console.log("setted url:", url)
-  console.log("---------------------")
 
   return <img src={url} />
 }

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -44,11 +44,6 @@ export default (props: {
   imgDataSetter?: (urlData: UrlData | null) => void,
   preSavedS3UrlData?: UrlData,
 }) => {
-  // only gets passed along to main image
-  console.log("__imgDataSetter", props.imgDataSetter)
-  // only gets passed along to preview image
-  console.log("__preSavedS3UrlData", props.preSavedS3UrlData)
-  console.log("__interactionHint", props.interactionHint)
   const Component = getComponent(props.contentType)
   if (Component == null) return null
 
@@ -88,20 +83,14 @@ const EvidenceCodeblock = (props: EvidenceProps) => {
 
 const EvidenceImage = (props: EvidenceProps) => {
   let url = `/web/operations/${props.operationSlug}/evidence/${props.evidenceUuid}/media`
-  // TODO TN might be able to get rid o thifs
-  const now = new Date()
-  console.log("preSavedS3UrlData", props.preSavedS3UrlData)
-  console.log("imgDataSetter", props.imgDataSetter)
-  if (props.useS3Url && props.preSavedS3UrlData && new Date(props.preSavedS3UrlData.expirationTime) > now){
+  if (props.useS3Url && props.preSavedS3UrlData && new Date(props.preSavedS3UrlData.expirationTime) > new Date()){
     url = props.preSavedS3UrlData.url
   } else if (props.useS3Url) {
-    console.log("fetching new url")
     const wiredUrl = useWiredData<UrlData>(React.useCallback(() => getEvidenceAsUrlData({
       operationSlug: props.operationSlug,
       evidenceUuid: props.evidenceUuid,
     }), [props.operationSlug, props.evidenceUuid]))
     wiredUrl.expose(s3url => {
-      console.log("setting new url", s3url)
       props.imgDataSetter && props.imgDataSetter(s3url)
       url = s3url.url 
     })

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -111,9 +111,10 @@ const sameURL = (prevProps: EvidenceProps, nextProps: EvidenceProps) => {
   console.log("nextProps", nextProps?.preSavedS3UrlData)
   console.log("last url, new url", prevProps?.preSavedS3UrlData?.url.slice(-3), nextProps?.preSavedS3UrlData?.url.slice(-3))
   console.log("is true or false?", prevProps?.preSavedS3UrlData?.url === nextProps?.preSavedS3UrlData?.url)
-  const sameUrl = prevProps?.preSavedS3UrlData?.url === nextProps?.preSavedS3UrlData?.url
+  // const sameUrl = prevProps?.preSavedS3UrlData?.url === nextProps?.preSavedS3UrlData?.url
   const sameUuid = prevProps.evidenceUuid === nextProps.evidenceUuid
-  return sameUrl && sameUuid
+  // return sameUrl && sameUuid
+  return sameUuid
 };
 
 const MemoizedEvidenceImage = React.memo(EvidenceImage, sameURL);

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -80,17 +80,17 @@ const EvidenceCodeblock = (props: EvidenceProps) => {
 }
 
 const EvidenceImage = (props: EvidenceProps) => {
-  const { imgDataSetter, imgData, evidence } = useEvidenceContext()
+  const { imgDataSetter, imgData, activeEvidence } = useEvidenceContext()
 
 
   console.log("---------------------")
   console.log("viewHint in same URL", props?.viewHint)
   console.log("EvidenceImage props", imgData?.url.slice(-3))
   console.log("imgData:", imgData)
-  console.log("sendUrl", evidence?.sendUrl)
+  console.log("sendUrl", props.useS3Url)
   let url = `/web/operations/${props.operationSlug}/evidence/${props.evidenceUuid}/media`
 
-  if (imgData && props.useS3Url && isAfter(new Date(imgData.expirationTime), new Date())) {
+  if (imgData && props.useS3Url && isAfter(new Date(imgData.expirationTime), new Date()) && (props.evidenceUuid === activeEvidence?.uuid)) {
     url = imgData.url
   } else if (props.useS3Url) {
     console.log("getting s3 url")

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -87,9 +87,9 @@ const EvidenceImage = (props: EvidenceProps) => {
   console.log("EvidenceImage props", props?.preSavedS3UrlData?.url.slice(-3))
   console.log("---------------------")
   let url = `/web/operations/${props.operationSlug}/evidence/${props.evidenceUuid}/media`
-  if (props.useS3Url && props.preSavedS3UrlData && new Date(props.preSavedS3UrlData.expirationTime) > new Date()){
-    url = props.preSavedS3UrlData.url
-  } else if (props.useS3Url) {
+  // if (props.useS3Url && props.preSavedS3UrlData && new Date(props.preSavedS3UrlData.expirationTime) > new Date()){
+    // url = props.preSavedS3UrlData.url
+  // } else if (props.useS3Url) {
     const wiredUrl = useWiredData<UrlData>(React.useCallback(() => getEvidenceAsUrlData({
       operationSlug: props.operationSlug,
       evidenceUuid: props.evidenceUuid,
@@ -98,7 +98,7 @@ const EvidenceImage = (props: EvidenceProps) => {
       props.imgDataSetter && props.imgDataSetter(s3url)
       url = s3url.url 
     })
-  }
+  // }
   return <img src={url} />
 }
 

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -44,7 +44,9 @@ export default (props: {
   imgDataSetter?: (urlData: UrlData | null) => void,
   preSavedS3UrlData?: UrlData,
 }) => {
+  // only gets passed along to main image
   console.log("__imgDataSetter", props.imgDataSetter)
+  // only gets passed along to preview image
   console.log("__preSavedS3UrlData", props.preSavedS3UrlData)
   console.log("__interactionHint", props.interactionHint)
   const Component = getComponent(props.contentType)

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -90,7 +90,7 @@ const EvidenceImage = (props: EvidenceProps) => {
   console.log("sendUrl", evidence?.sendUrl)
   let url = `/web/operations/${props.operationSlug}/evidence/${props.evidenceUuid}/media`
 
-  if (imgData && props.useS3Url && isAfter(imgData.expirationTime, new Date())) {
+  if (imgData && props.useS3Url && isAfter(new Date(imgData.expirationTime), new Date())) {
     url = imgData.url
   } else if (props.useS3Url) {
     console.log("getting s3 url")

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -103,12 +103,16 @@ const EvidenceImage = (props: EvidenceProps) => {
 }
 
 const sameURL = (prevProps: EvidenceProps, nextProps: EvidenceProps) => {
+  console.log("prevProps.evidenceUuid", prevProps.evidenceUuid)
+  console.log("nextProps.evidenceUuid", nextProps.evidenceUuid)
   console.log("viewHint in same URL", prevProps?.viewHint, nextProps?.viewHint)
   console.log("prevProps", prevProps?.preSavedS3UrlData)
   console.log("nextProps", nextProps?.preSavedS3UrlData)
   console.log("last url, new url", prevProps?.preSavedS3UrlData?.url.slice(-3), nextProps?.preSavedS3UrlData?.url.slice(-3))
   console.log("is true or false?", prevProps?.preSavedS3UrlData?.url === nextProps?.preSavedS3UrlData?.url)
-  return prevProps?.preSavedS3UrlData?.url === nextProps?.preSavedS3UrlData?.url;
+  const sameUrl = prevProps?.preSavedS3UrlData?.url === nextProps?.preSavedS3UrlData?.url
+  const sameUuid = prevProps.evidenceUuid === nextProps.evidenceUuid
+  return sameUrl && sameUuid
 };
 
 const MemoizedEvidenceImage = React.memo(EvidenceImage, sameURL);

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -95,6 +95,7 @@ const EvidenceImage = (props: EvidenceProps) => {
       evidenceUuid: props.evidenceUuid,
     }), [props.operationSlug, props.evidenceUuid]))
     wiredUrl.expose(s3url => {
+      console.log("about to set img data", s3url)
       props.imgDataSetter && props.imgDataSetter(s3url)
       url = s3url.url 
     })

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -84,6 +84,7 @@ const EvidenceCodeblock = (props: EvidenceProps) => {
 const EvidenceImage = (props: EvidenceProps) => {
   let url = `/web/operations/${props.operationSlug}/evidence/${props.evidenceUuid}/media`
   const now = new Date()
+  console.log("preSavedS3UrlData", props.preSavedS3UrlData)
   if (props.useS3Url && props.preSavedS3UrlData && new Date(props.preSavedS3UrlData.expirationTime) > now){
     url = props.preSavedS3UrlData.url
   } else if (props.useS3Url) {

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -44,6 +44,9 @@ export default (props: {
   imgDataSetter?: (urlData: UrlData | null) => void,
   preSavedS3UrlData?: UrlData,
 }) => {
+  console.log("__imgDataSetter", props.imgDataSetter)
+  console.log("__preSavedS3UrlData", props.preSavedS3UrlData)
+  console.log("__interactionHint", props.interactionHint)
   const Component = getComponent(props.contentType)
   if (Component == null) return null
 

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -82,7 +82,7 @@ const EvidenceCodeblock = (props: EvidenceProps) => {
 }
 
 const EvidenceImage = (props: EvidenceProps) => {
-  console.log("EvidenceImage props", props?.preSavedS3UrlData?.url)
+  console.log("EvidenceImage props", props?.preSavedS3UrlData?.url.slice(-3))
   let url = `/web/operations/${props.operationSlug}/evidence/${props.evidenceUuid}/media`
   if (props.useS3Url && props.preSavedS3UrlData && new Date(props.preSavedS3UrlData.expirationTime) > new Date()){
     url = props.preSavedS3UrlData.url
@@ -100,7 +100,8 @@ const EvidenceImage = (props: EvidenceProps) => {
 }
 
 const sameURL = (prevProps: EvidenceProps, nextProps: EvidenceProps) => {
-  console.log("sameURL props", prevProps?.preSavedS3UrlData?.url, nextProps?.preSavedS3UrlData?.url)
+  console.log("sameURL props", prevProps?.preSavedS3UrlData?.url.slice(-3), nextProps?.preSavedS3UrlData?.url.slice(-3))
+  console.log("is true or false?", prevProps?.preSavedS3UrlData?.url === nextProps?.preSavedS3UrlData?.url)
   return prevProps?.preSavedS3UrlData?.url === nextProps?.preSavedS3UrlData?.url;
 };
 

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -90,10 +90,8 @@ const EvidenceImage = (props: EvidenceProps) => {
   const imgData = cachedUrls.get(props.evidenceUuid)
 
   if (shouldUseCachedUrl(imgData, props)) {
-    console.log("using cached url")
     url = imgData?.url as string
   } else if (props.useS3Url) {
-    console.log("getting url from s3")
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const wiredUrl = useWiredData<UrlData>(React.useCallback(() => getEvidenceAsUrlData({
       operationSlug: props.operationSlug,

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -82,7 +82,9 @@ const EvidenceCodeblock = (props: EvidenceProps) => {
 }
 
 const EvidenceImage = (props: EvidenceProps) => {
+  console.log("---------------------")
   console.log("EvidenceImage props", props?.preSavedS3UrlData?.url.slice(-3))
+  console.log("---------------------")
   let url = `/web/operations/${props.operationSlug}/evidence/${props.evidenceUuid}/media`
   if (props.useS3Url && props.preSavedS3UrlData && new Date(props.preSavedS3UrlData.expirationTime) > new Date()){
     url = props.preSavedS3UrlData.url
@@ -100,7 +102,9 @@ const EvidenceImage = (props: EvidenceProps) => {
 }
 
 const sameURL = (prevProps: EvidenceProps, nextProps: EvidenceProps) => {
-  console.log("sameURL props", prevProps?.preSavedS3UrlData?.url.slice(-3), nextProps?.preSavedS3UrlData?.url.slice(-3))
+  console.log("prevProps", prevProps?.preSavedS3UrlData)
+  console.log("nextProps", nextProps?.preSavedS3UrlData)
+  console.log("last url, new url", prevProps?.preSavedS3UrlData?.url.slice(-3), nextProps?.preSavedS3UrlData?.url.slice(-3))
   console.log("is true or false?", prevProps?.preSavedS3UrlData?.url === nextProps?.preSavedS3UrlData?.url)
   return prevProps?.preSavedS3UrlData?.url === nextProps?.preSavedS3UrlData?.url;
 };

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -85,6 +85,7 @@ const EvidenceImage = (props: EvidenceProps) => {
   let url = `/web/operations/${props.operationSlug}/evidence/${props.evidenceUuid}/media`
   const now = new Date()
   console.log("preSavedS3UrlData", props.preSavedS3UrlData)
+  console.log("imgDataSetter", props.imgDataSetter)
   if (props.useS3Url && props.preSavedS3UrlData && new Date(props.preSavedS3UrlData.expirationTime) > now){
     url = props.preSavedS3UrlData.url
   } else if (props.useS3Url) {

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -41,7 +41,7 @@ export default (props: {
   fitToContainer?: boolean,
   useS3Url: boolean,
   onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void,
-  urlSetter?: (urlData: UrlData | null) => void,
+  imgDataSetter?: (urlData: UrlData | null) => void,
   preSavedS3UrlData?: UrlData,
 }) => {
   const Component = getComponent(props.contentType)
@@ -68,7 +68,7 @@ type EvidenceProps = {
   viewHint?: EvidenceViewHint,
   interactionHint?: InteractionHint,
   useS3Url: boolean
-  urlSetter?: (urlData: UrlData) => void,
+  imgDataSetter?: (urlData: UrlData) => void,
   preSavedS3UrlData?: UrlData,
 }
 
@@ -88,13 +88,15 @@ const EvidenceImage = (props: EvidenceProps) => {
   if (props.useS3Url && props.preSavedS3UrlData && new Date(props.preSavedS3UrlData.expirationTime) > now){
     url = props.preSavedS3UrlData.url
   } else if (props.useS3Url) {
+    console.log("fetching new url")
     const wiredUrl = useWiredData<UrlData>(React.useCallback(() => getEvidenceAsUrlData({
       operationSlug: props.operationSlug,
       evidenceUuid: props.evidenceUuid,
     }), [props.operationSlug, props.evidenceUuid]))
     wiredUrl.expose(s3url => {
-      props.urlSetter && props.urlSetter(s3url)
-      url = s3url.url
+      console.log("setting new url", s3url)
+      props.imgDataSetter && props.imgDataSetter(s3url)
+      url = s3url.url 
     })
   }
   return <img src={url} />

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -83,6 +83,7 @@ const EvidenceCodeblock = (props: EvidenceProps) => {
 
 const EvidenceImage = (props: EvidenceProps) => {
   console.log("---------------------")
+  console.log("viewHint in same URL", props?.viewHint)
   console.log("EvidenceImage props", props?.preSavedS3UrlData?.url.slice(-3))
   console.log("---------------------")
   let url = `/web/operations/${props.operationSlug}/evidence/${props.evidenceUuid}/media`
@@ -102,6 +103,7 @@ const EvidenceImage = (props: EvidenceProps) => {
 }
 
 const sameURL = (prevProps: EvidenceProps, nextProps: EvidenceProps) => {
+  console.log("viewHint in same URL", prevProps?.viewHint, nextProps?.viewHint)
   console.log("prevProps", prevProps?.preSavedS3UrlData)
   console.log("nextProps", nextProps?.preSavedS3UrlData)
   console.log("last url, new url", prevProps?.preSavedS3UrlData?.url.slice(-3), nextProps?.preSavedS3UrlData?.url.slice(-3))

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -82,7 +82,7 @@ const EvidenceCodeblock = (props: EvidenceProps) => {
 }
 
 const EvidenceImage = (props: EvidenceProps) => {
-  console.log("EvidenceImage props", props)
+  console.log("EvidenceImage props", props?.preSavedS3UrlData?.url)
   let url = `/web/operations/${props.operationSlug}/evidence/${props.evidenceUuid}/media`
   if (props.useS3Url && props.preSavedS3UrlData && new Date(props.preSavedS3UrlData.expirationTime) > new Date()){
     url = props.preSavedS3UrlData.url
@@ -100,7 +100,7 @@ const EvidenceImage = (props: EvidenceProps) => {
 }
 
 const sameURL = (prevProps: EvidenceProps, nextProps: EvidenceProps) => {
-  console.log("sameURL props", prevProps, nextProps)
+  console.log("sameURL props", prevProps?.preSavedS3UrlData?.url, nextProps?.preSavedS3UrlData?.url)
   return prevProps?.preSavedS3UrlData?.url === nextProps?.preSavedS3UrlData?.url;
 };
 

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -82,6 +82,7 @@ const EvidenceCodeblock = (props: EvidenceProps) => {
 }
 
 const EvidenceImage = (props: EvidenceProps) => {
+  console.log("EvidenceImage props", props)
   let url = `/web/operations/${props.operationSlug}/evidence/${props.evidenceUuid}/media`
   if (props.useS3Url && props.preSavedS3UrlData && new Date(props.preSavedS3UrlData.expirationTime) > new Date()){
     url = props.preSavedS3UrlData.url
@@ -99,6 +100,7 @@ const EvidenceImage = (props: EvidenceProps) => {
 }
 
 const sameURL = (prevProps: EvidenceProps, nextProps: EvidenceProps) => {
+  console.log("sameURL props", prevProps, nextProps)
   return prevProps?.preSavedS3UrlData?.url === nextProps?.preSavedS3UrlData?.url;
 };
 

--- a/frontend/src/components/evidence_preview/index.tsx
+++ b/frontend/src/components/evidence_preview/index.tsx
@@ -88,6 +88,7 @@ const EvidenceCodeblock = (props: EvidenceProps) => {
 
 const EvidenceImage = (props: EvidenceProps) => {
   let url = `/web/operations/${props.operationSlug}/evidence/${props.evidenceUuid}/media`
+  // TODO TN might be able to get rid o thifs
   const now = new Date()
   console.log("preSavedS3UrlData", props.preSavedS3UrlData)
   console.log("imgDataSetter", props.imgDataSetter)

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -89,6 +89,7 @@ export default (props: {
     <div className={cx('root')} ref={rootRef}>
       {props.evidence.map((evi, idx) => {
         const active = activeChildIndex === idx
+        console.log("evi active", evi.uuid, active)
         return (
           <TimelineRow
             {...props}

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -83,6 +83,10 @@ export default (props: {
 
   const activeEvidence = props.evidence[activeChildIndex]
   if (activeEvidence == null) return null
+  const imgDataSetter = (data: any) => {
+    console.log("imgDataSetter data", data)
+    return setCurrImageData(data)
+  }
 
   return <>
     <div className={cx('root')} ref={rootRef}>
@@ -93,7 +97,7 @@ export default (props: {
             {...props}
             focusUuid={props.scrollToUuid}
             active={active}
-            imgDataSetter={active ? setCurrImageData : undefined}
+            imgDataSetter={active ? imgDataSetter : undefined}
             evidence={evi}
             key={evi.uuid}
             onPreviewClick={() => { setActiveChildIndex(idx); setQuicklookVisible(true) }}
@@ -114,7 +118,7 @@ export default (props: {
           evidenceUuid={activeEvidence.uuid}
           contentType={activeEvidence.contentType}
           useS3Url={activeEvidence.sendUrl}
-          imgDataSetter={setCurrImageData}
+          imgDataSetter={imgDataSetter}
           // imgDataSetter={quicklookVisible ? setCurrImageData : undefined}
           preSavedS3UrlData={currImageData ? currImageData : undefined}
           viewHint="large"

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -36,7 +36,7 @@ export default (props: {
 
   const [activeChildIndex, setActiveChildIndex] = React.useState<number>(0)
   const [quicklookVisible, setQuicklookVisible] = React.useState<boolean>(false)
-  const [currImageUrlData, setCurrImageUrlData] = React.useState<UrlData| null>(null)
+  const [currImageData, setCurrImageData] = React.useState<UrlData| null>(null)
 
   const onKeyDown = (e: KeyboardEvent) => {
     // Only handle keystrokes if nothing is focused (target is body)
@@ -93,7 +93,7 @@ export default (props: {
             {...props}
             focusUuid={props.scrollToUuid}
             active={active}
-            urlSetter={active ? setCurrImageUrlData : undefined}
+            imgDataSetter={active ? setCurrImageData : undefined}
             evidence={evi}
             key={evi.uuid}
             onPreviewClick={() => { setActiveChildIndex(idx); setQuicklookVisible(true) }}
@@ -114,7 +114,7 @@ export default (props: {
           evidenceUuid={activeEvidence.uuid}
           contentType={activeEvidence.contentType}
           useS3Url={activeEvidence.sendUrl}
-          preSavedS3UrlData={currImageUrlData ? currImageUrlData : undefined}
+          preSavedS3UrlData={currImageData ? currImageData : undefined}
           viewHint="large"
           interactionHint="active"
         />
@@ -134,7 +134,7 @@ const TimelineRow = (props: {
   focusUuid?: string,
   onPreviewClick: () => void,
   onClick: () => void,
-  urlSetter?: (urlData: UrlData | null) => void,
+  imgDataSetter?: (urlData: UrlData | null) => void,
 }) => {
   const self = React.useRef<null | HTMLDivElement>(null)
 
@@ -167,7 +167,7 @@ const TimelineRow = (props: {
           evidenceUuid={props.evidence.uuid}
           contentType={props.evidence.contentType}
           useS3Url={props.evidence.sendUrl}
-          urlSetter={props.urlSetter}
+          imgDataSetter={props.imgDataSetter}
           viewHint="medium"
           interactionHint="inactive"
         />

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -121,7 +121,8 @@ export default (props: {
           evidenceUuid={activeEvidence.uuid}
           contentType={activeEvidence.contentType}
           useS3Url={activeEvidence.sendUrl}
-          imgDataSetter={(quicklookVisible && expired) ? setCurrImageData : undefined}
+          imgDataSetter={quicklookVisible ? setCurrImageData : undefined}
+          // imgDataSetter={(quicklookVisible && expired) ? setCurrImageData : undefined}
           // TODO TN replace this with ?? operator
           // TODO TN clean this up
           preSavedS3UrlData={expired ? undefined : (currImageData ? currImageData : undefined)}

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -12,6 +12,7 @@ import { default as Button, ButtonGroup } from 'src/components/button'
 import { CopyTextButton } from 'src/components/text_copiers'
 import { format } from 'date-fns'
 import { default as Menu, MenuItem } from 'src/components/menu'
+import EvidencesContextProvider from 'src/contexts/evidences_context'
 
 const cx = classnames.bind(require('./stylesheet'))
 
@@ -36,7 +37,7 @@ export default (props: {
 
   const [activeChildIndex, setActiveChildIndex] = React.useState<number>(0)
   const [quicklookVisible, setQuicklookVisible] = React.useState<boolean>(false)
-  const [currImageData, setCurrImageData] = React.useState<UrlData| null>(null)
+  // const [currImageData, setCurrImageData] = React.useState<UrlData| null>(null)
 
   const onKeyDown = (e: KeyboardEvent) => {
     // Only handle keystrokes if nothing is focused (target is body)
@@ -83,26 +84,28 @@ export default (props: {
 
   const activeEvidence = props.evidence[activeChildIndex]
   if (activeEvidence == null) return null
-  const imgDataSetter = (data: any) => {
-    console.log("imgDataSetter data", data)
-    return setCurrImageData(data)
-  }
+  // const imgDataSetter = (data: any) => {
+  //   console.log("imgDataSetter data", data)
+  //   return setCurrImageData(data)
+  // }
 
   return <>
     <div className={cx('root')} ref={rootRef}>
       {props.evidence.map((evi, idx) => {
         const active = activeChildIndex === idx
         return (
-          <TimelineRow
-            {...props}
-            focusUuid={props.scrollToUuid}
-            active={active}
-            imgDataSetter={active ? imgDataSetter : undefined}
-            evidence={evi}
-            key={evi.uuid}
-            onPreviewClick={() => { setActiveChildIndex(idx); setQuicklookVisible(true) }}
-            onClick={() => setActiveChildIndex(idx)}
-          />
+          <EvidencesContextProvider evidence={evi}>
+            <TimelineRow
+              {...props}
+              focusUuid={props.scrollToUuid}
+              active={active}
+              // imgDataSetter={active ? imgDataSetter : undefined}
+              evidence={evi}
+              key={evi.uuid}
+              onPreviewClick={() => { setActiveChildIndex(idx); setQuicklookVisible(true) }}
+              onClick={() => setActiveChildIndex(idx)}
+            />
+          </EvidencesContextProvider>
         )
       })}
       <Help className={cx('help')}
@@ -113,17 +116,18 @@ export default (props: {
     <Lightbox canUseFitToggle={activeEvidence.contentType == "image"}
       isOpen={quicklookVisible} onRequestClose={() => setQuicklookVisible(false)}>
       <div ref={lightboxRef}>
-        <EvidencePreview
-          operationSlug={props.operationSlug}
-          evidenceUuid={activeEvidence.uuid}
-          contentType={activeEvidence.contentType}
-          useS3Url={activeEvidence.sendUrl}
-          imgDataSetter={imgDataSetter}
-          // imgDataSetter={quicklookVisible ? setCurrImageData : undefined}
-          preSavedS3UrlData={currImageData ? currImageData : undefined}
-          viewHint="large"
-          interactionHint="active"
-        />
+        <EvidencesContextProvider evidence={activeEvidence}>
+          <EvidencePreview
+            operationSlug={props.operationSlug}
+            evidenceUuid={activeEvidence.uuid}
+            contentType={activeEvidence.contentType}
+            useS3Url={activeEvidence.sendUrl}
+            // imgDataSetter={quicklookVisible ? setCurrImageData : undefined}
+            // preSavedS3UrlData={currImageData ? currImageData : undefined}
+            viewHint="large"
+            interactionHint="active"
+          />
+        </EvidencesContextProvider>
       </div>
     </Lightbox>
   </>
@@ -173,7 +177,7 @@ const TimelineRow = (props: {
           evidenceUuid={props.evidence.uuid}
           contentType={props.evidence.contentType}
           useS3Url={props.evidence.sendUrl}
-          imgDataSetter={props.imgDataSetter}
+          // imgDataSetter={props.imgDataSetter}
           viewHint="medium"
           interactionHint="inactive"
         />

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -125,7 +125,7 @@ export default (props: {
           // imgDataSetter={(quicklookVisible && expired) ? setCurrImageData : undefined}
           // TODO TN replace this with ?? operator
           // TODO TN clean this up
-          preSavedS3UrlData={expired ? undefined : (currImageData ? currImageData : undefined)}
+          preSavedS3UrlData={currImageData ? currImageData : undefined}
           viewHint="large"
           interactionHint="active"
         />

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -85,6 +85,11 @@ export default (props: {
   const activeEvidence = props.evidence[activeChildIndex]
   if (activeEvidence == null) return null
 
+  const expDate = currImageData?.expirationTime
+  const now = new Date()
+  const expired = currImageData?.expirationTime ? new Date(currImageData?.expirationTime) > now : true
+
+
   return <>
     <div className={cx('root')} ref={rootRef}>
       {props.evidence.map((evi, idx) => {
@@ -116,9 +121,10 @@ export default (props: {
           evidenceUuid={activeEvidence.uuid}
           contentType={activeEvidence.contentType}
           useS3Url={activeEvidence.sendUrl}
-          imgDataSetter={quicklookVisible ? setCurrImageData : undefined}
+          imgDataSetter={(quicklookVisible && expired) ? setCurrImageData : undefined}
           // TODO TN replace this with ?? operator
-          preSavedS3UrlData={currImageData ? currImageData : undefined}
+          // TODO TN clean this up
+          preSavedS3UrlData={expired ? undefined : (currImageData ? currImageData : undefined)}
           viewHint="large"
           interactionHint="active"
         />

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -6,7 +6,7 @@ import TagList from 'src/components/tag_list'
 import classnames from 'classnames/bind'
 import Help from 'src/components/help'
 import { ClickPopover } from 'src/components/popover'
-import { Tag, Evidence, UrlData } from 'src/global_types'
+import { Tag, Evidence } from 'src/global_types'
 import { addTagToQuery, addOperatorToQuery } from 'src/helpers'
 import { default as Button, ButtonGroup } from 'src/components/button'
 import { CopyTextButton } from 'src/components/text_copiers'
@@ -134,8 +134,7 @@ const TimelineRow = (props: {
   query: string,
   focusUuid?: string,
   onPreviewClick: () => void,
-  onClick: () => void,
-  imgDataSetter?: (urlData: UrlData | null) => void,
+  onClick: () => void
 }) => {
   const self = React.useRef<null | HTMLDivElement>(null)
 

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -89,48 +89,46 @@ export default (props: {
   //   return setCurrImageData(data)
   // }
 
-  return <>
-    <div className={cx('root')} ref={rootRef}>
-      {props.evidence.map((evi, idx) => {
-        const active = activeChildIndex === idx
-        return (
-          <EvidencesContextProvider evidence={evi}>
-            <TimelineRow
-              {...props}
-              focusUuid={props.scrollToUuid}
-              active={active}
-              // imgDataSetter={active ? imgDataSetter : undefined}
-              evidence={evi}
-              key={evi.uuid}
-              onPreviewClick={() => { setActiveChildIndex(idx); setQuicklookVisible(true) }}
-              onClick={() => setActiveChildIndex(idx)}
-            />
-          </EvidencesContextProvider>
-        )
-      })}
-      <Help className={cx('help')}
-        preamble="Review and Edit the accumulated evidence for this operation"
-        shortcuts={KeyboardShortcuts}
-      />
-    </div>
-    <Lightbox canUseFitToggle={activeEvidence.contentType == "image"}
-      isOpen={quicklookVisible} onRequestClose={() => setQuicklookVisible(false)}>
-      <div ref={lightboxRef}>
-        <EvidencesContextProvider evidence={activeEvidence}>
-          <EvidencePreview
-            operationSlug={props.operationSlug}
-            evidenceUuid={activeEvidence.uuid}
-            contentType={activeEvidence.contentType}
-            useS3Url={activeEvidence.sendUrl}
-            // imgDataSetter={quicklookVisible ? setCurrImageData : undefined}
-            // preSavedS3UrlData={currImageData ? currImageData : undefined}
-            viewHint="large"
-            interactionHint="active"
-          />
-        </EvidencesContextProvider>
+  return (
+    <EvidencesContextProvider activeEvidence={activeEvidence}>
+      <div className={cx('root')} ref={rootRef}>
+        {props.evidence.map((evi, idx) => {
+          const active = activeChildIndex === idx
+          return (
+              <TimelineRow
+                {...props}
+                focusUuid={props.scrollToUuid}
+                active={active}
+                // imgDataSetter={active ? imgDataSetter : undefined}
+                evidence={evi}
+                key={evi.uuid}
+                onPreviewClick={() => { setActiveChildIndex(idx); setQuicklookVisible(true) }}
+                onClick={() => setActiveChildIndex(idx)}
+              />
+          )
+        })}
+        <Help className={cx('help')}
+          preamble="Review and Edit the accumulated evidence for this operation"
+          shortcuts={KeyboardShortcuts}
+        />
       </div>
-    </Lightbox>
-  </>
+      <Lightbox canUseFitToggle={activeEvidence.contentType == "image"}
+        isOpen={quicklookVisible} onRequestClose={() => setQuicklookVisible(false)}>
+        <div ref={lightboxRef}>
+            <EvidencePreview
+              operationSlug={props.operationSlug}
+              evidenceUuid={activeEvidence.uuid}
+              contentType={activeEvidence.contentType}
+              useS3Url={activeEvidence.sendUrl}
+              // imgDataSetter={quicklookVisible ? setCurrImageData : undefined}
+              // preSavedS3UrlData={currImageData ? currImageData : undefined}
+              viewHint="large"
+              interactionHint="active"
+            />
+        </div>
+      </Lightbox>
+    </EvidencesContextProvider>
+  )
 }
 
 const TimelineRow = (props: {

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -84,10 +84,6 @@ export default (props: {
 
   const activeEvidence = props.evidence[activeChildIndex]
   if (activeEvidence == null) return null
-  // const imgDataSetter = (data: any) => {
-  //   console.log("imgDataSetter data", data)
-  //   return setCurrImageData(data)
-  // }
 
   return (
     <EvidencesContextProvider activeEvidence={activeEvidence}>
@@ -99,7 +95,6 @@ export default (props: {
                 {...props}
                 focusUuid={props.scrollToUuid}
                 active={active}
-                // imgDataSetter={active ? imgDataSetter : undefined}
                 evidence={evi}
                 key={evi.uuid}
                 onPreviewClick={() => { setActiveChildIndex(idx); setQuicklookVisible(true) }}
@@ -120,8 +115,6 @@ export default (props: {
               evidenceUuid={activeEvidence.uuid}
               contentType={activeEvidence.contentType}
               useS3Url={activeEvidence.sendUrl}
-              // imgDataSetter={quicklookVisible ? setCurrImageData : undefined}
-              // preSavedS3UrlData={currImageData ? currImageData : undefined}
               viewHint="large"
               interactionHint="active"
             />
@@ -175,7 +168,6 @@ const TimelineRow = (props: {
           evidenceUuid={props.evidence.uuid}
           contentType={props.evidence.contentType}
           useS3Url={props.evidence.sendUrl}
-          // imgDataSetter={props.imgDataSetter}
           viewHint="medium"
           interactionHint="inactive"
         />

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -86,7 +86,7 @@ export default (props: {
   if (activeEvidence == null) return null
 
   return (
-    <EvidencesContextProvider activeEvidence={activeEvidence}>
+    <EvidencesContextProvider>
       <div className={cx('root')} ref={rootRef}>
         {props.evidence.map((evi, idx) => {
           const active = activeChildIndex === idx

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -37,6 +37,7 @@ export default (props: {
   const [activeChildIndex, setActiveChildIndex] = React.useState<number>(0)
   const [quicklookVisible, setQuicklookVisible] = React.useState<boolean>(false)
   const [currImageData, setCurrImageData] = React.useState<UrlData| null>(null)
+  console.log("currImageData", currImageData)
 
   const onKeyDown = (e: KeyboardEvent) => {
     // Only handle keystrokes if nothing is focused (target is body)

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -37,7 +37,6 @@ export default (props: {
   const [activeChildIndex, setActiveChildIndex] = React.useState<number>(0)
   const [quicklookVisible, setQuicklookVisible] = React.useState<boolean>(false)
   const [currImageData, setCurrImageData] = React.useState<UrlData| null>(null)
-  console.log("currImageData", currImageData)
 
   const onKeyDown = (e: KeyboardEvent) => {
     // Only handle keystrokes if nothing is focused (target is body)
@@ -85,16 +84,10 @@ export default (props: {
   const activeEvidence = props.evidence[activeChildIndex]
   if (activeEvidence == null) return null
 
-  const expDate = currImageData?.expirationTime
-  const now = new Date()
-  const expired = currImageData?.expirationTime ? new Date(currImageData?.expirationTime) > now : true
-
-
   return <>
     <div className={cx('root')} ref={rootRef}>
       {props.evidence.map((evi, idx) => {
         const active = activeChildIndex === idx
-        console.log("evi active", evi.uuid, active)
         return (
           <TimelineRow
             {...props}
@@ -122,9 +115,6 @@ export default (props: {
           contentType={activeEvidence.contentType}
           useS3Url={activeEvidence.sendUrl}
           imgDataSetter={quicklookVisible ? setCurrImageData : undefined}
-          // imgDataSetter={(quicklookVisible && expired) ? setCurrImageData : undefined}
-          // TODO TN replace this with ?? operator
-          // TODO TN clean this up
           preSavedS3UrlData={currImageData ? currImageData : undefined}
           viewHint="large"
           interactionHint="active"

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -116,6 +116,8 @@ export default (props: {
           evidenceUuid={activeEvidence.uuid}
           contentType={activeEvidence.contentType}
           useS3Url={activeEvidence.sendUrl}
+          imgDataSetter={quicklookVisible ? setCurrImageData : undefined}
+          // TODO TN replace this with ?? operator
           preSavedS3UrlData={currImageData ? currImageData : undefined}
           viewHint="large"
           interactionHint="active"

--- a/frontend/src/components/timeline/index.tsx
+++ b/frontend/src/components/timeline/index.tsx
@@ -114,7 +114,8 @@ export default (props: {
           evidenceUuid={activeEvidence.uuid}
           contentType={activeEvidence.contentType}
           useS3Url={activeEvidence.sendUrl}
-          imgDataSetter={quicklookVisible ? setCurrImageData : undefined}
+          imgDataSetter={setCurrImageData}
+          // imgDataSetter={quicklookVisible ? setCurrImageData : undefined}
           preSavedS3UrlData={currImageData ? currImageData : undefined}
           viewHint="large"
           interactionHint="active"

--- a/frontend/src/contexts/evidences_context/index.tsx
+++ b/frontend/src/contexts/evidences_context/index.tsx
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React, { PropsWithChildren, createContext, useContext } from 'react';
-import { UrlData, Evidence } from 'src/global_types';
+import { UrlData } from 'src/global_types';
 
 interface IEvidencesContext {
 	imgDataSetter: (key: string, urlData: UrlData) => void
@@ -17,10 +17,9 @@ export const useEvidenceContext = () => {
 }
 
 interface EvidencesContextProviderProps {
-	activeEvidence: Evidence
 }
 
-const EvidencesContextProvider: React.FC<PropsWithChildren<EvidencesContextProviderProps>> = ({ children, activeEvidence }) => {
+const EvidencesContextProvider: React.FC<PropsWithChildren<EvidencesContextProviderProps>> = ({ children }) => {
 	const [cachedUrls, setCachedUrls] = React.useState<Map<string, UrlData>>(new Map())
 
 	return (

--- a/frontend/src/contexts/evidences_context/index.tsx
+++ b/frontend/src/contexts/evidences_context/index.tsx
@@ -1,0 +1,48 @@
+import _ from 'lodash';
+import React, { PropsWithChildren, createContext, useContext } from 'react';
+import { UrlData, Evidence } from 'src/global_types';
+
+interface IEvidencesContext {
+	imgDataSetter: (urlData: UrlData | null) => void
+	imgData: UrlData | null
+	evidence?: Evidence
+}
+
+export const EvidencesContext = createContext<IEvidencesContext>({
+	imgData: null,
+	evidence: undefined,
+	imgDataSetter: () => 0,
+})
+
+export const useEvidenceContext = () => {
+	return useContext(EvidencesContext)
+}
+
+interface EvidencesContextProviderProps {
+	evidence: Evidence
+}
+
+const EvidencesContextProvider: React.FC<PropsWithChildren<EvidencesContextProviderProps>> = ({ children, evidence }) => {
+	const [currImageData, setCurrImageData] = React.useState<UrlData| null>(null)
+
+	return (
+		<EvidencesContext.Provider value={{
+			imgData: currImageData,
+			// This should prevent possible accidental state updates, since although
+			// the object could be equal, the reference is different, which would trigger
+			// a state update
+			imgDataSetter: (newData) => setCurrImageData(currData => {
+				if (_.isEqual(newData, currData)) {
+					return currData
+				}
+
+				return newData
+			}),
+			evidence
+		}}>
+			{children}
+		</EvidencesContext.Provider>
+	);
+}
+
+export default EvidencesContextProvider;

--- a/frontend/src/contexts/evidences_context/index.tsx
+++ b/frontend/src/contexts/evidences_context/index.tsx
@@ -5,12 +5,11 @@ import { UrlData, Evidence } from 'src/global_types';
 interface IEvidencesContext {
 	imgDataSetter: (urlData: UrlData | null) => void
 	imgData: UrlData | null
-	evidence?: Evidence
+	activeEvidence?: Evidence
 }
 
 export const EvidencesContext = createContext<IEvidencesContext>({
 	imgData: null,
-	evidence: undefined,
 	imgDataSetter: () => 0,
 })
 
@@ -19,10 +18,10 @@ export const useEvidenceContext = () => {
 }
 
 interface EvidencesContextProviderProps {
-	evidence: Evidence
+	activeEvidence: Evidence
 }
 
-const EvidencesContextProvider: React.FC<PropsWithChildren<EvidencesContextProviderProps>> = ({ children, evidence }) => {
+const EvidencesContextProvider: React.FC<PropsWithChildren<EvidencesContextProviderProps>> = ({ children, activeEvidence }) => {
 	const [currImageData, setCurrImageData] = React.useState<UrlData| null>(null)
 
 	return (
@@ -38,7 +37,7 @@ const EvidencesContextProvider: React.FC<PropsWithChildren<EvidencesContextProvi
 
 				return newData
 			}),
-			evidence
+			activeEvidence
 		}}>
 			{children}
 		</EvidencesContext.Provider>

--- a/frontend/src/contexts/evidences_context/index.tsx
+++ b/frontend/src/contexts/evidences_context/index.tsx
@@ -3,14 +3,13 @@ import React, { PropsWithChildren, createContext, useContext } from 'react';
 import { UrlData, Evidence } from 'src/global_types';
 
 interface IEvidencesContext {
-	imgDataSetter: (urlData: UrlData | null) => void
-	imgData: UrlData | null
-	activeEvidence?: Evidence
+	imgDataSetter: (key: string, urlData: UrlData) => void
+	cachedUrls: Map<string, UrlData>
 }
 
 export const EvidencesContext = createContext<IEvidencesContext>({
-	imgData: null,
 	imgDataSetter: () => 0,
+	cachedUrls: new Map()
 })
 
 export const useEvidenceContext = () => {
@@ -22,22 +21,18 @@ interface EvidencesContextProviderProps {
 }
 
 const EvidencesContextProvider: React.FC<PropsWithChildren<EvidencesContextProviderProps>> = ({ children, activeEvidence }) => {
-	const [currImageData, setCurrImageData] = React.useState<UrlData| null>(null)
+	const [cachedUrls, setCachedUrls] = React.useState<Map<string, UrlData>>(new Map())
 
 	return (
 		<EvidencesContext.Provider value={{
-			imgData: currImageData,
-			// This should prevent possible accidental state updates, since although
-			// the object could be equal, the reference is different, which would trigger
-			// a state update
-			imgDataSetter: (newData) => setCurrImageData(currData => {
-				if (_.isEqual(newData, currData)) {
-					return currData
-				}
+			imgDataSetter: (key, urlData) => {
+				const newCachedUrls = new Map(cachedUrls)
 
-				return newData
-			}),
-			activeEvidence
+				newCachedUrls.set(key, urlData)
+
+				setCachedUrls(newCachedUrls)
+			},
+			cachedUrls
 		}}>
 			{children}
 		</EvidencesContext.Provider>


### PR DESCRIPTION
Previously, after 30 minutes the initial presigned url for an image expired, and clicking on an image to view it full screen would generate a new presigned url every time (instead of creating a new presigned URL and using that for the duration of the url). This fixes that bug, and uses the same presigned url until it expires. I also updated the names of a few variables to match their functionality 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
