### PR TITLE
Tn/fix squl3 error

### DIFF
--- a/Dockerfile.dev.backend
+++ b/Dockerfile.dev.backend
@@ -2,7 +2,7 @@ FROM golang:1.20.11-alpine
 
 RUN apk add --no-cache git inotify-tools g++ && \
     rm -rf /var/cache/apk/* && \
-    go install -v github.com/rubenv/sql-migrate/sql-migrate@v1.1.0
+    go install -v github.com/rubenv/sql-migrate/sql-migrate@latest
 
 RUN mkdir /typescript-dtos
 RUN mkdir /app

--- a/Dockerfile.dev.backend
+++ b/Dockerfile.dev.backend
@@ -1,8 +1,8 @@
-FROM golang:1.20-alpine
+FROM golang:1.20.11-alpine
 
 RUN apk add --no-cache git inotify-tools g++ && \
     rm -rf /var/cache/apk/* && \
-    go install -v github.com/rubenv/sql-migrate/sql-migrate@latest
+    go install -v github.com/rubenv/sql-migrate/sql-migrate@v1.1.0
 
 RUN mkdir /typescript-dtos
 RUN mkdir /app


### PR DESCRIPTION
This fixes an sqlite3 error that was occurring when running `go install -v github.com/rubenv/sql-migrate/sql-migrate@v1.1.0` in `Dockerfile.dev.backend`; the error was caused by the go 1.20.12 update that occurred on Dec 5th

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
