### PR TITLE
Ability to configure S3 path style URLs

### DIFF
--- a/backend/Readme.md
+++ b/backend/Readme.md
@@ -42,6 +42,9 @@ Configuration is handled entirely via environment variables. To that end, here a
       * `STORE_REGION`
         * The cloud provider region where the files will be stored
         * Used with `s3` deployments
+      * `STORE_S3_USE_PATH_STYLE`
+        * Set to "1" to configure the client to use path-style bucket URLs (https://<s3_host>/<bucket>/<key> vs https://<bucket>.<s3_host>/<key)
+        * Used with `s3` deployments
   * `APP_CSRF_AUTH_KEY`
     * The actual authorization key
     * Web Only

--- a/backend/config/confighelpers/choose_contentstore.go
+++ b/backend/config/confighelpers/choose_contentstore.go
@@ -20,6 +20,9 @@ func ChooseContentStoreType(cfg config.ContentStoreConfig) (contentstore.Store, 
 		return contentstore.NewMemStore()
 	}
 	if cfg.Type == "s3" {
+		if cfg.S3UsePathStyle {
+			return contentstore.NewS3Store(cfg.Bucket, cfg.Region, contentstore.S3UsePathStyle)
+		}
 		return contentstore.NewS3Store(cfg.Bucket, cfg.Region)
 	}
 	if cfg.Type == "gcp" {

--- a/backend/config/webconfig.go
+++ b/backend/config/webconfig.go
@@ -31,9 +31,10 @@ type DBConfig struct {
 }
 
 type ContentStoreConfig struct {
-	Type   string `split_words:"true"`
-	Bucket string `split_words:"true"`
-	Region string `split_words:"true"`
+	Type           string `split_words:"true"`
+	Bucket         string `split_words:"true"`
+	Region         string `split_words:"true"`
+	S3UsePathStyle bool   `split_words:"true"`
 }
 
 var (

--- a/backend/contentstore/s3store.go
+++ b/backend/contentstore/s3store.go
@@ -20,15 +20,23 @@ type S3Store struct {
 }
 
 // NewS3Store provides a mechanism to initialize an S3 bucket in a particular region
-func NewS3Store(bucketName string, region string) (*S3Store, error) {
+func NewS3Store(bucketName string, region string, optsFns ...func(*s3.Options)) (*S3Store, error) {
 	cfg, err := config.LoadDefaultConfig(context.Background())
 	if err != nil {
 		return nil, backend.WrapError("Unable to establish an s3 session", err)
 	}
 	return &S3Store{
 		bucketName: bucketName,
-		s3Client:   s3.NewFromConfig(cfg),
+		s3Client:   s3.NewFromConfig(cfg, optsFns...),
 	}, nil
+}
+
+// S3UsePathStyle is a s3.config function that allows you to enable the client to use
+// path-style addressing, i.e., https:// s3.amazonaws.com/BUCKET/KEY .
+// By default, the S3 client will use virtual hosted bucket addressing when
+// possible( https://BUCKET.s3.amazonaws.com/KEY ).
+func S3UsePathStyle(opts *s3.Options) {
+	opts.UsePathStyle = true
 }
 
 // Upload stores a file in the Amazon S3 bucket configured when the S3 store was created


### PR DESCRIPTION
This PR adds an environment variable that configures the s3 client to use path-style URLs when resolving a bucket.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
