### PR TITLE
exports evidence storage keys

### DIFF
--- a/backend/dtos/dtos.go
+++ b/backend/dtos/dtos.go
@@ -14,13 +14,15 @@ type APIKey struct {
 }
 
 type Evidence struct {
-	UUID        string    `json:"uuid"`
-	Description string    `json:"description"`
-	OccurredAt  time.Time `json:"occurredAt"`
-	Operator    User      `json:"operator"`
-	Tags        []Tag     `json:"tags"`
-	ContentType string    `json:"contentType"`
-	SendUrl     bool      `json:"sendUrl"`
+	UUID          string    `json:"uuid"`
+	Description   string    `json:"description"`
+	OccurredAt    time.Time `json:"occurredAt"`
+	Operator      User      `json:"operator"`
+	Tags          []Tag     `json:"tags"`
+	ContentType   string    `json:"contentType"`
+	SendUrl       bool      `json:"sendUrl"`
+	ThumbImageKey string    `json:"thumbImageKey"`
+	FullImageKey  string    `json:"fullImageKey"`
 }
 
 type EvidenceMetadata struct {

--- a/backend/services/evidence.go
+++ b/backend/services/evidence.go
@@ -283,6 +283,8 @@ func ListEvidenceForOperation(ctx context.Context, db *database.Connection, cont
 			"users.first_name",
 			"users.last_name",
 			"users.slug",
+			"full_image_key",
+			"thumb_image_key",
 		)
 
 	if i.Filters.SortAsc {
@@ -332,13 +334,15 @@ func ListEvidenceForOperation(ctx context.Context, db *database.Connection, cont
 		}
 
 		evidenceDTO[idx] = &dtos.Evidence{
-			UUID:        evi.UUID,
-			Description: evi.Description,
-			Operator:    dtos.User{FirstName: evi.FirstName, LastName: evi.LastName, Slug: evi.Slug},
-			OccurredAt:  evi.OccurredAt,
-			ContentType: evi.ContentType,
-			Tags:        tags,
-			SendUrl:     sendURL,
+			UUID:          evi.UUID,
+			Description:   evi.Description,
+			Operator:      dtos.User{FirstName: evi.FirstName, LastName: evi.LastName, Slug: evi.Slug},
+			OccurredAt:    evi.OccurredAt,
+			ContentType:   evi.ContentType,
+			Tags:          tags,
+			SendUrl:       sendURL,
+			FullImageKey:  evi.FullImageKey,
+			ThumbImageKey: evi.ThumbImageKey,
 		}
 	}
 	return evidenceDTO, nil


### PR DESCRIPTION
This exposes "full_image_key" and "thumb_image_key" db fields so API consumers can make assumptions about how to retrieve Ashirt assets from external objectstores. 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
