### PR TITLE
DRAFT: Enable remote debugging (DO NOT MERGE)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,7 @@ jobs:
     strategy:
       matrix:
         service: [frontend,web,api,init]
+        debug_mode: ["debug",""]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -55,9 +56,9 @@ jobs:
         with:
           images: ashirt/${{ matrix.service }} # list of Docker images to use as base name for tags
           tags: |
-            type=sha
-            type=ref,event=branch
-            type=ref,event=pr
+            type=sha,suffix=${{ matrix_debug }}
+            type=ref,event=branch,suffix=${{ matrix_debug }}
+            type=ref,event=pr,suffix=${{ matrix_debug }}
           flavor: |
             latest=false
       - name: Login to Docker Hub
@@ -78,6 +79,7 @@ jobs:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           platforms: linux/amd64
+          build-args: DEBUG=${{ matrix.debug_mode }}
           push: true # Push with pr-### and sha-xxxxxxx tags
 
       - name: Build and Push Latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         service: [frontend,web,api,init]
-        debug_mode: ["debug",""]
+        debug_mode: ["-debug",""] # Conditional tag for debug images
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -56,9 +56,9 @@ jobs:
         with:
           images: ashirt/${{ matrix.service }} # list of Docker images to use as base name for tags
           tags: |
-            type=sha,suffix=${{ matrix_debug }}
-            type=ref,event=branch,suffix=${{ matrix_debug }}
-            type=ref,event=pr,suffix=${{ matrix_debug }}
+            type=sha,suffix=${{ matrix.debug_mode }}
+            type=ref,event=branch,suffix=${{ matrix.debug_mode }}
+            type=ref,event=pr,suffix=${{ matrix.debug_mode }}
           flavor: |
             latest=false
       - name: Login to Docker Hub
@@ -79,7 +79,7 @@ jobs:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           platforms: linux/amd64
-          build-args: DEBUG=${{ matrix.debug_mode }}
+          build-args: DEBUG=${{ matrix.debug_mode == '-debug' }} # True if "-debug", false if absent
           push: true # Push with pr-### and sha-xxxxxxx tags
 
       - name: Build and Push Latest

--- a/Dockerfile.prod.web
+++ b/Dockerfile.prod.web
@@ -11,12 +11,12 @@ RUN go mod download
 
 COPY backend backend
 COPY signer signer
-RUN go build ./backend/bin/web/
+RUN go build -gcflags "all=-N -l" ./backend/bin/web/
 
 
 FROM alpine:latest
 
-RUN apk add --no-cache ca-certificates && \
+RUN apk add --no-cache ca-certificates delve && \
     adduser -h /home/ashirt -S -D ashirt
 
 USER ashirt
@@ -25,4 +25,4 @@ WORKDIR /home/ashirt
 COPY --from=build /build/web /home/ashirt/public-api
 COPY backend/migrations /migrations
 
-CMD /home/ashirt/public-api
+CMD dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient exec /home/ashirt/public-api --continue

--- a/Dockerfile.prod.web
+++ b/Dockerfile.prod.web
@@ -1,4 +1,5 @@
 FROM golang:1.21-alpine AS build
+ARG DEBUG=false
 
 RUN apk add --no-cache git && \
     rm -rf /var/cache/apk/*
@@ -11,13 +12,17 @@ RUN go mod download
 
 COPY backend backend
 COPY signer signer
-RUN go build -gcflags "all=-N -l" ./backend/bin/web/
+RUN if [ $DEBUG == false ] ; then go build ./backend/bin/web/; else go build -gcflags "all=-N -l" ./backend/bin/web/; fi
 
 
 FROM alpine:latest
+ARG DEBUG=false
+ENV DEBUG=$DEBUG
 
-RUN apk add --no-cache ca-certificates delve && \
+RUN apk add --no-cache ca-certificates && \
     adduser -h /home/ashirt -S -D ashirt
+
+RUN if [ $DEBUG == false ] ; then continue; else apk add --no-cache delve; fi
 
 USER ashirt
 WORKDIR /home/ashirt
@@ -25,4 +30,4 @@ WORKDIR /home/ashirt
 COPY --from=build /build/web /home/ashirt/public-api
 COPY backend/migrations /migrations
 
-CMD dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient exec /home/ashirt/public-api --continue
+CMD if [ $DEBUG == false ] ; then /home/ashirt/public-api ; else dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient exec /home/ashirt/public-api --continue ; fi

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -6,6 +6,7 @@ services:
       dockerfile: Dockerfile.prod.web
     ports:
       - 8000:8000
+      - 2345:2345
     restart: on-failure
     environment:
       APP_CSRF_AUTH_KEY: "dummy-csrf-for-testing-prod-locally"


### PR DESCRIPTION
**DO NOT MERGE**

This enables remote debugging in the prod containers. We've noticed a recurring issue where the server becomes unresponsive after migrating from our EKS deployment to ECS after a period of time. We originally assumed this was related to a memory leak or file descriptor leak. After monitoring both it doesn't seem to be related. Let's get some container built that we can deploy and attach delve.

**DO NOT DEPLOY THESE UNLESS YOU KNOW WHAT YOU ARE DOING**

We might want to end up producing an image that is debugable and setup either dev or a separate docker compose file to use it.