### PR TITLE
fix: text editor stuck in 6 lines size

### DIFF
--- a/frontend/src/components/evidence_preview/stylesheet.styl
+++ b/frontend/src/components/evidence_preview/stylesheet.styl
@@ -1,5 +1,9 @@
 @import '~src/vars'
 
+
+.root.codeblock > div
+  height: 100%
+
 .root.image
   &.fit
     display: inline


### PR DESCRIPTION
Somehow a there was classless div between the evidence_preview codeblock and ace editor (code-viewer) divs that was limiting the height of the ace editor codeblock, all that was necessary was set this div height to 100% for everything to work.

The div between the other two mentioned divs:
![image](https://github.com/ashirt-ops/ashirt-server/assets/48929501/11f5c4b0-6df6-400f-afc0-8d7d6c4d3dc4)