### PR TITLE
Removing workers build from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,32 +98,14 @@ services:
       - MYSQL_PASSWORD=dev-user-password
 
   demo:
-    build:
-      context: enhancement_workers/demo-tesseract
-      dockerfile: Dockerfile.dev
+    image: ashirt/tesseract-lambda-python:latest
     ports:
       - 3001:3001
     restart: on-failure
-    volumes:
-      - ./enhancement_workers/demo-tesseract/src:/app/src
     environment:
       PORT: 3001
       ENABLE_DEV: "true"
       ASHIRT_BACKEND_URL: http://backend:3000
-      ASHIRT_ACCESS_KEY: gR6nVtaQmp2SvzIqLUWdedDk
-      ASHIRT_SECRET_KEY: WvtvxFaJS0mPs82nCzqamI+bOGXpq7EIQhg4UD8nxS5448XG9N0gNAceJGBLPdCA3kAzC4MdUSHnKCJ/lZD++A==
-
-  hasher:
-    build:
-      context: enhancement_workers/demo-lambda-hasher
-      dockerfile: Dockerfile
-    ports:
-      - 3002:8080
-    restart: on-failure
-    environment:
-      ENABLE_DEV: "true"
-      ASHIRT_BACKEND_URL: backend
-      ASHIRT_BACKEND_PORT: 3000
       ASHIRT_ACCESS_KEY: gR6nVtaQmp2SvzIqLUWdedDk
       ASHIRT_SECRET_KEY: WvtvxFaJS0mPs82nCzqamI+bOGXpq7EIQhg4UD8nxS5448XG9N0gNAceJGBLPdCA3kAzC4MdUSHnKCJ/lZD++A==
 


### PR DESCRIPTION
We moved the workers to https://github.com/ashirt-ops/ashirt-workers and regular builds happen there. Updating the compose files to pull the images instead.

Remove the hasher demo since it doesn't offer much utility at this point. 