### PR TITLE
Add validation to create evidence form

### DIFF
--- a/frontend/src/pages/operation_show/evidence_modals/index.tsx
+++ b/frontend/src/pages/operation_show/evidence_modals/index.tsx
@@ -90,6 +90,18 @@ export const CreateEvidenceModal = (props: {
   const [selectedCBValue, setSelectedCBValue] = React.useState<string>(evidenceTypeOptions[0].value)
   const getSelectedOption = () => evidenceTypeOptions.filter(opt => opt.value === selectedCBValue)[0]
 
+  // Validation logic for description and content fields
+  const validateForm = () => {
+    const errors = []
+    if (descriptionField.value.trim() === "") {
+      errors.push("Description cannot be empty.")
+    }
+    if (getSelectedOption().value !== 'event' && binaryBlobField.value === null && codeblockField.value.code.trim() === "") {
+      errors.push("Evidence content cannot be empty.")
+    }
+    return errors
+  }
+
   const formComponentProps = useForm({
     fields: [descriptionField, binaryBlobField, adjustedAtField],
     onSuccess: () => { props.onCreated(); props.onRequestClose() },
@@ -104,6 +116,11 @@ export const CreateEvidenceModal = (props: {
         data = { type: selectedOption.value, file: binaryBlobField.value }
       } else if (selectedOption.value === 'event') {
         data = { type: 'event' }
+      }
+
+      const formErrors = validateForm()
+      if (formErrors.length > 0) {
+        return Promise.reject(new Error(formErrors.join("\n")))
       }
 
       return createEvidence({


### PR DESCRIPTION
Related to #1088

This pull request introduces validation logic to the `CreateEvidenceModal` component to ensure that both the description and evidence content fields are not empty before submission. This change addresses the issue of being able to submit blank evidence, enhancing the form's data integrity.

- Adds a `validateForm` function that checks for non-empty description and evidence content. It generates an array of error messages if validation fails.
- Modifies the `handleSubmit` function within `useForm` hook to include a call to `validateForm`. If validation errors exist, the submission is halted, and errors are displayed to the user.
- Maintains the existing functionality of evidence type selection and file upload, ensuring that the validation logic seamlessly integrates without disrupting the user experience.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ashirt-ops/ashirt-server/issues/1088?shareId=67c8d37c-03bf-4b4e-ad5c-9500c7ba4b6f).