### PR TITLE
fix: lines not wrapping in evidence metadata field

### DIFF
--- a/frontend/src/pages/operation_show/evidence_modals/stylesheet.styl
+++ b/frontend/src/pages/operation_show/evidence_modals/stylesheet.styl
@@ -14,11 +14,12 @@
   margin-top: 10px
 
 .metadata-content
-  flex-grow: 1
-  display: inline-block
+  display: block
   font-weight: normal
   padding-left: 5px
   padding-bottom: 5px
+  white-space: pre-wrap
+  word-wrap: break-word
 
 .label-not-important
   color: #777
@@ -39,7 +40,6 @@
   margin-right: 10px
 
 .expandable-section-label
-  white-space: nowrap
   text-overflow: ellipsis
   overflow: hidden
 


### PR DESCRIPTION
Fix long metadata text not wrapping inside the metadata view
