### PR TITLE
Add OIDC client specific urls

### DIFF
--- a/backend/config/authconfig.go
+++ b/backend/config/authconfig.go
@@ -28,15 +28,18 @@ type AuthInstanceConfig struct {
 }
 
 type OIDCConfig struct {
-	FriendlyName          string `split_words:"true"`
-	ProviderURL           string `split_words:"true"`
-	ClientID              string `split_words:"true"`
-	ClientSecret          string `split_words:"true"`
-	Scopes                string
-	ProfileFirstNameField string `split_words:"true"`
-	ProfileLastNameField  string `split_words:"true"`
-	ProfileEmailField     string `split_words:"true"`
-	ProfileSlugField      string `split_words:"true"`
+	FriendlyName             string `split_words:"true"`
+	ProviderURL              string `split_words:"true"`
+	ClientID                 string `split_words:"true"`
+	ClientSecret             string `split_words:"true"`
+	Scopes                   string
+	ProfileFirstNameField    string `split_words:"true"`
+	ProfileLastNameField     string `split_words:"true"`
+	ProfileEmailField        string `split_words:"true"`
+	ProfileSlugField         string `split_words:"true"`
+	BackendURL               string `split_words:"true"`
+	SuccessRedirectURL       string `split_words:"true"`
+	FailureRedirectURLPrefix string `split_words:"true"`
 }
 
 type WebauthnConfig struct {


### PR DESCRIPTION
This optionally allows you to specify the the url of the ashirt server to redirect to after login specific to the OIDC client. This is necessary in environments where you may have two different domains attached to the same instance with two different OIDC configs (eg. a corp one and an OOB one). This is sort of a hacky solution and we should be able to create a more automated one but we'll likely need to redesign some of the auth stack first to do so.

<!--
Thank you for your interest in and contributing to ASHIRT! There
are a few simple things to check before submitting your pull request
that can help with the review process. We only seek to accept code that you are authorized to contribute to the project. This pull request template is included on our projects so that your contributions are made with the following confirmation: I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
-->

- Please review our [contributing guidelines](https://github.com/ashirt-ops/ashirt-server/blob/master/Contributing.md)
- Please review our [Code of Conduct](https://github.com/ashirt-ops/ashirt-server/blob/master/Code-of-Conduct.md)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
