### PR TITLE
chore: migrate routing from chi to weby

### DIFF
--- a/backend/authschemes/auth_scheme.go
+++ b/backend/authschemes/auth_scheme.go
@@ -1,7 +1,7 @@
 package authschemes
 
 import (
-	"github.com/go-chi/chi/v5"
+	"net/http"
 )
 
 // AuthScheme provides a small interface into interacting with the AShirt backend authentication.
@@ -16,11 +16,11 @@ import (
 // from any other scheme. Likewise, it should be a "friendlier" version of Name(), though it need
 // not be.
 //
-// BindRoutes(router, authBridge): BindRoutes exposes a _namespaced_ router that the authentication
-// system can use to register custom endpoints. Each router is prefixed with /auth/{name} (as
+// BindRoutes(mux, authBridge): BindRoutes exposes a _namespaced_ mux that the authentication
+// system can use to register custom endpoints. Each mux is prefixed with /auth/{name} (as
 // determined by the Name() method)
 type AuthScheme interface {
-	BindRoutes(chi.Router, AShirtAuthBridge)
+	BindRoutes(*http.ServeMux, AShirtAuthBridge)
 	Name() string
 	FriendlyName() string
 	Flags() []string

--- a/backend/authschemes/localauth/local_auth.go
+++ b/backend/authschemes/localauth/local_auth.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ashirt-ops/ashirt-server/backend/dtos"
 	"github.com/ashirt-ops/ashirt-server/backend/server/middleware"
 	"github.com/ashirt-ops/ashirt-server/backend/server/remux"
-	"github.com/go-chi/chi/v5"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -74,7 +73,7 @@ func (LocalAuthScheme) Type() string {
 //
 // In each case above, the actual action is deferred to the bridge connecting this auth scheme to
 // the underlying system/database
-func (p LocalAuthScheme) BindRoutes(r chi.Router, bridge authschemes.AShirtAuthBridge) {
+func (p LocalAuthScheme) BindRoutes(r *http.ServeMux, bridge authschemes.AShirtAuthBridge) {
 	remux.Route(r, "POST", "/register", remux.JSONHandler(func(r *http.Request) (interface{}, error) {
 		if !p.RegistrationEnabled {
 			return nil, fmt.Errorf("registration is closed to users")

--- a/backend/authschemes/oidcauth/oidc_auth.go
+++ b/backend/authschemes/oidcauth/oidc_auth.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ashirt-ops/ashirt-server/backend/server/middleware"
 	"github.com/ashirt-ops/ashirt-server/backend/server/remux"
 	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/go-chi/chi/v5"
 	"golang.org/x/oauth2"
 )
 
@@ -104,7 +103,7 @@ func (OIDCAuth) Flags() []string {
 	return []string{}
 }
 
-func (o OIDCAuth) BindRoutes(r chi.Router, bridge authschemes.AShirtAuthBridge) {
+func (o OIDCAuth) BindRoutes(r *http.ServeMux, bridge authschemes.AShirtAuthBridge) {
 	remux.Route(r, "GET", "/login", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		o.redirectLogin(w, r, bridge, modeLogin)
 	}))

--- a/backend/authschemes/recoveryauth/recovery_auth.go
+++ b/backend/authschemes/recoveryauth/recovery_auth.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ashirt-ops/ashirt-server/backend/logging"
 	"github.com/ashirt-ops/ashirt-server/backend/server/middleware"
 	"github.com/ashirt-ops/ashirt-server/backend/server/remux"
-	"github.com/go-chi/chi/v5"
 )
 
 type RecoveryAuthScheme struct {
@@ -42,7 +41,7 @@ func (RecoveryAuthScheme) Type() string {
 	return constants.Code
 }
 
-func (p RecoveryAuthScheme) BindRoutes(r chi.Router, bridge authschemes.AShirtAuthBridge) {
+func (p RecoveryAuthScheme) BindRoutes(r *http.ServeMux, bridge authschemes.AShirtAuthBridge) {
 	remux.Route(r, "POST", "/generate", remux.JSONHandler(func(r *http.Request) (interface{}, error) {
 		dr := remux.DissectJSONRequest(r)
 		userSlug := dr.FromBody("userSlug").Required().AsString()

--- a/backend/authschemes/webauthn/webauthn.go
+++ b/backend/authschemes/webauthn/webauthn.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ashirt-ops/ashirt-server/backend/helpers"
 	"github.com/ashirt-ops/ashirt-server/backend/server/middleware"
 	"github.com/ashirt-ops/ashirt-server/backend/server/remux"
-	"github.com/go-chi/chi/v5"
 
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
@@ -104,7 +103,7 @@ func isDiscoverable(r *http.Request) bool {
 	return parsedURL.Query().Get("discoverable") == "true"
 }
 
-func (a WebAuthn) BindRoutes(r chi.Router, bridge authschemes.AShirtAuthBridge) {
+func (a WebAuthn) BindRoutes(r *http.ServeMux, bridge authschemes.AShirtAuthBridge) {
 	remux.Route(r, "POST", "/register/begin", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		remux.JSONHandler(func(r *http.Request) (interface{}, error) {
 			// validate basic registration data

--- a/backend/bin/web/web.go
+++ b/backend/bin/web/web.go
@@ -20,7 +20,8 @@ import (
 	"github.com/ashirt-ops/ashirt-server/backend/logging"
 	"github.com/ashirt-ops/ashirt-server/backend/server"
 	"github.com/ashirt-ops/ashirt-server/backend/workers"
-	"github.com/go-chi/chi/v5"
+	"github.com/jrozner/weby"
+	webyMiddleware "github.com/jrozner/weby/middleware"
 )
 
 type SchemeError struct {
@@ -85,27 +86,26 @@ func main() {
 		logger.Warn("No Emailer selected")
 	}
 
-	r := chi.NewRouter()
+	mux := weby.NewServeMux()
+	mux.Use(webyMiddleware.RequestID)
+	mux.Use(webyMiddleware.WrapResponse)
+	mux.Use(webyMiddleware.Logger(logger))
 
-	r.Route("/web", func(r chi.Router) {
-		server.Web(r,
-			db, contentStore, &server.WebConfig{
-				SessionStoreKey:  []byte(config.SessionStoreKey()),
-				UseSecureCookies: true,
-				AuthSchemes:      schemes,
-				Logger:           logger,
-			},
-		)
+	webMux := http.NewServeMux()
+	server.Web(webMux, db, contentStore, &server.WebConfig{
+		SessionStoreKey:  []byte(config.SessionStoreKey()),
+		UseSecureCookies: true,
+		AuthSchemes:      schemes,
+		Logger:           logger,
 	})
+	mux.Handle("/web/", http.StripPrefix("/web", webMux))
 
-	r.Route("/api", func(r chi.Router) {
-		server.API(r,
-			db, contentStore, logger,
-		)
-	})
+	apiMux := http.NewServeMux()
+	server.API(apiMux, db, contentStore, logger)
+	mux.Handle("/api/", http.StripPrefix("/api", apiMux))
 
 	logger.Info("starting Web server", "port", config.Port())
-	serveErr := http.ListenAndServe(":"+config.Port(), r)
+	serveErr := http.ListenAndServe(":"+config.Port(), mux)
 	logging.Fatal(logger, "server shutting down", "err", serveErr)
 }
 

--- a/backend/server/dissectors/dissected_request_test.go
+++ b/backend/server/dissectors/dissected_request_test.go
@@ -47,7 +47,7 @@ const rawJSON = `{
 func TestGetRequiredAfterError(t *testing.T) {
 	rawBody, _ := prepInputData()
 	req := makeRequest(&rawBody, "")
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	str := pq.FromBody("DoesNotExit").Required().AsString()
 
@@ -67,7 +67,7 @@ func TestGetRequiredAfterError(t *testing.T) {
 
 func TestNoBody(t *testing.T) {
 	req := makeRequest(nil, "")
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	assert.Nil(t, pq.Error, "Should have no error")
 }
@@ -75,14 +75,14 @@ func TestNoBody(t *testing.T) {
 func TestNotJSONBody(t *testing.T) {
 	notJson := "[}"
 	req := makeRequest(&notJson, "")
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	assert.NotNil(t, pq.Error, "Should have a parse error")
 }
 
 func TestNoContentAsString(t *testing.T) {
 	req := makeRequest(nil, "")
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromBody("DoesNotExist").AsString()
 	expected := ""
@@ -93,7 +93,7 @@ func TestNoContentAsString(t *testing.T) {
 
 func TestNoContentAsRequiredString(t *testing.T) {
 	req := makeRequest(nil, "")
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromBody("DoesNotExist").Required().AsString()
 	expected := ""
@@ -104,7 +104,7 @@ func TestNoContentAsRequiredString(t *testing.T) {
 
 func TestNoContentAsInt64(t *testing.T) {
 	req := makeRequest(nil, "")
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromBody("DoesNotExist").AsInt64()
 	expected := int64(0)
@@ -117,7 +117,7 @@ func TestStringAsInt64(t *testing.T) {
 	// designed to fail, because we cannot convert a random string into an integer
 	rawBody, _ := prepInputData()
 	req := makeRequest(&rawBody, "")
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromBody("stringAsString").Required().AsInt64()
 	expected := int64(0)
@@ -128,7 +128,7 @@ func TestStringAsInt64(t *testing.T) {
 
 func TestNoContentAsRequiredInt64(t *testing.T) {
 	req := makeRequest(nil, "")
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromBody("DoesNotExist").Required().AsInt64()
 	expected := int64(0)
@@ -142,7 +142,7 @@ func TestNoContentAsRequiredInt64(t *testing.T) {
 func TestDefaultValue(t *testing.T) {
 	rawBody, _ := prepInputData()
 	req := makeRequest(&rawBody, "")
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	defaultValue := "It's Okay"
 	actual := pq.FromBody("DoesNotExist").OrDefault(defaultValue).AsString()
@@ -154,7 +154,7 @@ func TestDefaultValue(t *testing.T) {
 func TestRequiredValue_doesNotExist(t *testing.T) {
 	rawBody, _ := prepInputData()
 	req := makeRequest(&rawBody, "")
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromBody("DoesNotExist").Required().AsString()
 	expected := ""
@@ -167,7 +167,7 @@ func TestRequiredValue_doesNotExist(t *testing.T) {
 func TestParseStringFromBody(t *testing.T) {
 	rawBody, asStruct := prepInputData()
 	req := makeRequest(&rawBody, "")
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromBody("stringAsString").Required().AsString()
 	expected := asStruct.StringAsString
@@ -178,7 +178,7 @@ func TestParseStringFromBody(t *testing.T) {
 func TestParseIntFromBody(t *testing.T) {
 	rawBody, asStruct := prepInputData()
 	req := makeRequest(&rawBody, "")
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromBody("intAsNumber").Required().AsInt64()
 	expected := int64(asStruct.IntAsNumber)
@@ -189,7 +189,7 @@ func TestParseIntFromBody(t *testing.T) {
 func TestParseIntSliceFromBody(t *testing.T) {
 	rawBody, asStruct := prepInputData()
 	req := makeRequest(&rawBody, "")
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromBody("intSliceAsNumberArray").Required().AsInt64Slice()
 	expected := toInt64Slice(asStruct.IntSliceAsNumberArray)
@@ -200,7 +200,7 @@ func TestParseIntSliceFromBody(t *testing.T) {
 func TestParseStringSliceFromBody(t *testing.T) {
 	rawBody, asStruct := prepInputData()
 	req := makeRequest(&rawBody, "")
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromBody("stringSliceAsStringArray").Required().AsStringSlice()
 	expected := asStruct.StringSliceAsStringArray
@@ -211,7 +211,7 @@ func TestParseStringSliceFromBody(t *testing.T) {
 func TestParseTimeFromBody(t *testing.T) {
 	rawBody, asStruct := prepInputData()
 	req := makeRequest(&rawBody, "")
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromBody("timeAsRFC3339").Required().AsTime()
 	expected := asStruct.TimeAsRFC3339
@@ -222,7 +222,7 @@ func TestParseTimeFromBody(t *testing.T) {
 func TestParseFullTimeFromBody(t *testing.T) {
 	rawBody, asStruct := prepInputData()
 	req := makeRequest(&rawBody, "")
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromBody("timeAsRFC3339WithTZ").Required().AsTime()
 	expected := asStruct.TimeAsRFC3339WithTZ
@@ -233,7 +233,7 @@ func TestParseFullTimeFromBody(t *testing.T) {
 func TestParseBoolFromBody(t *testing.T) {
 	rawBody, asStruct := prepInputData()
 	req := makeRequest(&rawBody, "")
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromBody("boolAsBool").Required().AsBool()
 	expected := asStruct.BoolAsBool
@@ -246,7 +246,7 @@ func TestParseBoolFromBody(t *testing.T) {
 func TestParseStringFromQuery(t *testing.T) {
 	key, value := "key", "singleValue"
 	req := makeRequest(nil, fmt.Sprintf("%v=%v", key, value))
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromQuery(key).Required().AsString()
 	expected := value
@@ -257,7 +257,7 @@ func TestParseStringFromQuery(t *testing.T) {
 func TestParseIntFromQuery(t *testing.T) {
 	key, value := "key", int64(123)
 	req := makeRequest(nil, fmt.Sprintf("%v=%v", key, value))
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromQuery(key).Required().AsInt64()
 	expected := value
@@ -269,7 +269,7 @@ func TestParseIntSliceFromQuery(t *testing.T) {
 	key, value1 := "key", int64(123)
 	key, value2 := "key", int64(456)
 	req := makeRequest(nil, fmt.Sprintf("%v=%v&%v=%v", key, value1, key, value2))
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromQuery(key).Required().AsInt64Slice()
 	expected := []int64{value1, value2}
@@ -281,7 +281,7 @@ func TestParseStringSliceFromQuery(t *testing.T) {
 	key, value1 := "key", "dog"
 	key, value2 := "key", "cat"
 	req := makeRequest(nil, fmt.Sprintf("%v=%v&%v=%v", key, value1, key, value2))
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromQuery(key).Required().AsStringSlice()
 	expected := []string{value1, value2}
@@ -292,7 +292,7 @@ func TestParseStringSliceFromQuery(t *testing.T) {
 func TestParseTimeFromQuery(t *testing.T) {
 	key, value1 := "key", "2001-01-31T11:22:33Z"
 	req := makeRequest(nil, fmt.Sprintf("%v=%v", key, value1))
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromQuery(key).Required().AsTime()
 	expected, _ := time.Parse(time.RFC3339, value1)
@@ -303,7 +303,7 @@ func TestParseTimeFromQuery(t *testing.T) {
 func TestParseFullTimeFromQuery(t *testing.T) {
 	key, value1 := "key", "2001-01-31T11:22:33-07:00"
 	req := makeRequest(nil, fmt.Sprintf("%v=%v", key, value1))
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromQuery(key).Required().AsTime()
 	expected, _ := time.Parse(time.RFC3339, value1)
@@ -315,7 +315,7 @@ func TestParseMultipleValuesFromQuery(t *testing.T) {
 	key, value1, value2 := "key", int64(123), int64(456)
 	altKey, altValue := "mischief", "managed"
 	req := makeRequest(nil, fmt.Sprintf("%v=%v&%v=%v&%v=%v", key, value1, key, value2, altKey, altValue))
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual1 := pq.FromQuery(key).Required().AsInt64Slice()
 	expected1 := []int64{value1, value2}
@@ -330,7 +330,7 @@ func TestParseMultipleValuesFromQuery(t *testing.T) {
 func TestParseBoolFromQuery(t *testing.T) {
 	key, value := "key", true
 	req := makeRequest(nil, fmt.Sprintf("%v=%v", key, value))
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromQuery(key).Required().AsBool()
 	expected := value
@@ -341,7 +341,7 @@ func TestParseBoolFromQuery(t *testing.T) {
 func TestParseBoolFlagFromQuery(t *testing.T) {
 	key := "key"
 	req := makeRequest(nil, fmt.Sprintf("%v", key))
-	pq := extract.DissectJSONRequest(req, map[string]string{})
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromQuery(key).Required().AsBool()
 	expected := true
@@ -355,7 +355,9 @@ func TestParseStringFromURL(t *testing.T) {
 	req := makeRequest(nil, "")
 	key, value := "key", "value"
 	secondKey, secondValue := "key2", "value2"
-	pq := extract.DissectJSONRequest(req, makeUrlParamMap(key, value, secondKey, secondValue))
+	req.SetPathValue(key, value)
+	req.SetPathValue(secondKey, secondValue)
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromURL(key).Required().AsString()
 	expected := value
@@ -367,7 +369,9 @@ func TestParseInt64FromURL(t *testing.T) {
 	req := makeRequest(nil, "")
 	key, value := "key", "12"
 	secondKey, secondValue := "key2", "value2"
-	pq := extract.DissectJSONRequest(req, makeUrlParamMap(key, value, secondKey, secondValue))
+	req.SetPathValue(key, value)
+	req.SetPathValue(secondKey, secondValue)
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromURL(key).Required().AsInt64()
 	expected, _ := strconv.ParseInt(value, 10, 64)
@@ -379,7 +383,9 @@ func TestParseMultipleValuesFromURL(t *testing.T) {
 	req := makeRequest(nil, "")
 	key, value := "key", "12"
 	key2, value2 := "key2", "value2"
-	pq := extract.DissectJSONRequest(req, makeUrlParamMap(key, value, key2, value2))
+	req.SetPathValue(key, value)
+	req.SetPathValue(key2, value2)
+	pq := extract.DissectJSONRequest(req)
 
 	actualValue1 := pq.FromURL(key).Required().AsInt64()
 	expectedValue1, _ := strconv.ParseInt(value, 10, 64)
@@ -395,7 +401,8 @@ func TestParseMultipleValuesFromURL(t *testing.T) {
 func TestParseTimeFromURL(t *testing.T) {
 	key, value := "key", "2001-01-31T11:22:33Z"
 	req := makeRequest(nil, "")
-	pq := extract.DissectJSONRequest(req, makeUrlParamMap(key, value))
+	req.SetPathValue(key, value)
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromURL(key).Required().AsTime()
 	expected, _ := time.Parse(time.RFC3339, value)
@@ -406,7 +413,8 @@ func TestParseTimeFromURL(t *testing.T) {
 func TestParseFullTimeFromURL(t *testing.T) {
 	key, value := "key", "2001-01-31T11:22:33-07:00"
 	req := makeRequest(nil, "")
-	pq := extract.DissectJSONRequest(req, makeUrlParamMap(key, value))
+	req.SetPathValue(key, value)
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromURL(key).Required().AsTime()
 	expected, _ := time.Parse(time.RFC3339, value)
@@ -418,7 +426,9 @@ func TestParseBoolFromURL(t *testing.T) {
 	req := makeRequest(nil, "")
 	key, value := "key", "true"
 	secondKey, secondValue := "key2", "value2"
-	pq := extract.DissectJSONRequest(req, makeUrlParamMap(key, value, secondKey, secondValue))
+	req.SetPathValue(key, value)
+	req.SetPathValue(secondKey, secondValue)
+	pq := extract.DissectJSONRequest(req)
 
 	actual := pq.FromURL(key).Required().AsBool()
 	expected, _ := strconv.ParseBool(value)
@@ -449,17 +459,6 @@ func makeURL(queryString string) *url.URL {
 		RawQuery: queryString,
 	}
 	return &rtn
-}
-
-func makeUrlParamMap(values ...string) map[string]string {
-	if len(values)%2 == 1 {
-		panic("I need an even number of arguments!")
-	}
-	rtn := make(map[string]string)
-	for i := 0; i < len(values); i += 2 {
-		rtn[values[i]] = values[i+1]
-	}
-	return rtn
 }
 
 func prepInputData() (string, dummyRequest) {

--- a/backend/server/middleware/logger.go
+++ b/backend/server/middleware/logger.go
@@ -8,6 +8,18 @@ import (
 	"github.com/ashirt-ops/ashirt-server/backend/logging"
 )
 
+// InjectLogger is a thin middleware that injects a request-scoped logger into the context
+// via logging.AddRequestLogger. Use this alongside an external HTTP logging middleware (e.g.
+// weby's Logger) so that handlers and services can retrieve the logger via logging.ReqLogger(ctx).
+func InjectLogger(baseLogger *slog.Logger) MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx, _ := logging.AddRequestLogger(r.Context(), baseLogger)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
 type responseWriterWrapper struct {
 	http.ResponseWriter
 	size   int

--- a/backend/server/remux/dissector_wrappers.go
+++ b/backend/server/remux/dissector_wrappers.go
@@ -4,32 +4,19 @@ import (
 	"net/http"
 
 	"github.com/ashirt-ops/ashirt-server/backend/server/dissectors"
-	"github.com/go-chi/chi/v5"
 )
 
-func generateUrlParamMap(r *http.Request) map[string]string {
-	urlParamMap := map[string]string{}
-	cxt := chi.RouteContext(r.Context())
-	if cxt != nil {
-		urlParams := cxt.URLParams
-		for index, value := range urlParams.Keys {
-			urlParamMap[value] = urlParams.Values[index]
-		}
-	}
-	return urlParamMap
-}
-
-// DissectJSONRequest is a gorilla.mux focused rewrap of dissectors.DissectJSONRequest
+// DissectJSONRequest is a rewrap of dissectors.DissectJSONRequest
 func DissectJSONRequest(r *http.Request) dissectors.DissectedRequest {
-	return dissectors.DissectJSONRequest(r, generateUrlParamMap(r))
+	return dissectors.DissectJSONRequest(r)
 }
 
-// DissectFormRequest is a gorilla.mux focused rewrap of dissectors.DissectFormRequest
+// DissectFormRequest is a rewrap of dissectors.DissectFormRequest
 func DissectFormRequest(r *http.Request) dissectors.DissectedRequest {
-	return dissectors.DissectFormRequest(r, generateUrlParamMap(r))
+	return dissectors.DissectFormRequest(r)
 }
 
-// DissectNoBodyRequest is a gorilla.mux focused rewrap of dissectors.DissectPlainRequest
+// DissectNoBodyRequest is a rewrap of dissectors.DissectPlainRequest
 func DissectNoBodyRequest(r *http.Request) dissectors.DissectedRequest {
-	return dissectors.DissectPlainRequest(r, generateUrlParamMap(r))
+	return dissectors.DissectPlainRequest(r)
 }

--- a/backend/server/remux/routing_wrappers.go
+++ b/backend/server/remux/routing_wrappers.go
@@ -2,11 +2,10 @@ package remux
 
 import (
 	"net/http"
-
-	"github.com/go-chi/chi/v5"
 )
 
-// Route rewraps chi's Handle/Methods to provide a better at-a-glance reading of route definitions
-func Route(r chi.Router, method string, path string, handler http.Handler) {
-	r.Method(method, path, handler)
+// Route registers an HTTP handler for the given method and path on mux.
+// It combines method and path into the stdlib pattern format "METHOD /path".
+func Route(mux *http.ServeMux, method string, path string, handler http.Handler) {
+	mux.Handle(method+" "+path, handler)
 }

--- a/backend/server/route_helper.go
+++ b/backend/server/route_helper.go
@@ -10,11 +10,10 @@ import (
 
 	"github.com/ashirt-ops/ashirt-server/backend/server/dissectors"
 	"github.com/ashirt-ops/ashirt-server/backend/server/remux"
-	"github.com/go-chi/chi/v5"
 )
 
-func route(r chi.Router, method string, path string, handler http.Handler) {
-	remux.Route(r, method, path, handler)
+func route(mux *http.ServeMux, method string, path string, handler http.Handler) {
+	remux.Route(mux, method, path, handler)
 }
 
 func dissectJSONRequest(r *http.Request) dissectors.DissectedRequest {

--- a/backend/server/shared_routes.go
+++ b/backend/server/shared_routes.go
@@ -8,15 +8,14 @@ import (
 	"github.com/ashirt-ops/ashirt-server/backend/helpers"
 	"github.com/ashirt-ops/ashirt-server/backend/server/middleware"
 	"github.com/ashirt-ops/ashirt-server/backend/services"
-	"github.com/go-chi/chi/v5"
 )
 
-func bindSharedRoutes(r chi.Router, db *database.Connection, contentStore contentstore.Store) {
-	route(r, "GET", "/operations", jsonHandler(func(r *http.Request) (interface{}, error) {
+func bindSharedRoutes(mux *http.ServeMux, db *database.Connection, contentStore contentstore.Store) {
+	route(mux, "GET", "/operations", jsonHandler(func(r *http.Request) (interface{}, error) {
 		return services.ListOperations(r.Context(), db)
 	}))
 
-	route(r, "POST", "/operations", jsonHandler(func(r *http.Request) (interface{}, error) {
+	route(mux, "POST", "/operations", jsonHandler(func(r *http.Request) (interface{}, error) {
 		dr := dissectJSONRequest(r)
 		i := services.CreateOperationInput{
 			Slug:    dr.FromBody("slug").Required().AsString(),
@@ -29,7 +28,7 @@ func bindSharedRoutes(r chi.Router, db *database.Connection, contentStore conten
 		return services.CreateOperation(r.Context(), db, i)
 	}))
 
-	route(r, "GET", "/operations/{operation_slug}/tags", jsonHandler(func(r *http.Request) (interface{}, error) {
+	route(mux, "GET", "/operations/{operation_slug}/tags", jsonHandler(func(r *http.Request) (interface{}, error) {
 		dr := dissectJSONRequest(r)
 		i := services.ListTagsForOperationInput{
 			OperationSlug: dr.FromURL("operation_slug").Required().AsString(),
@@ -37,7 +36,7 @@ func bindSharedRoutes(r chi.Router, db *database.Connection, contentStore conten
 		return services.ListTagsForOperation(r.Context(), db, i)
 	}))
 
-	route(r, "POST", "/operations/{operation_slug}/tags", jsonHandler(func(r *http.Request) (interface{}, error) {
+	route(mux, "POST", "/operations/{operation_slug}/tags", jsonHandler(func(r *http.Request) (interface{}, error) {
 		dr := dissectJSONRequest(r)
 		i := services.CreateTagInput{
 			Name:          dr.FromBody("name").Required().AsString(),
@@ -51,7 +50,7 @@ func bindSharedRoutes(r chi.Router, db *database.Connection, contentStore conten
 		return services.CreateTag(r.Context(), db, i)
 	}))
 
-	route(r, "GET", "/operations/{operation_slug}/evidence", jsonHandler(func(r *http.Request) (interface{}, error) {
+	route(mux, "GET", "/operations/{operation_slug}/evidence", jsonHandler(func(r *http.Request) (interface{}, error) {
 		dr := dissectJSONRequest(r)
 		timelineFilters, err := helpers.ParseTimelineQuery(dr.FromQuery("query").AsString())
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	github.com/google/s2a-go v0.1.8 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.13.0 // indirect
+	github.com/jrozner/weby v0.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/jaytaylor/html2text v0.0.0-20211105163654-bc68cce691ba h1:QFQpJdgbON7
 github.com/jaytaylor/html2text v0.0.0-20211105163654-bc68cce691ba/go.mod h1:CVKlgaMiht+LXvHG173ujK6JUhZXKb2u/BQtjPDIvyk=
 github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
 github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
+github.com/jrozner/weby v0.1.0 h1:kI+DXnYHsSB6Kmmil8i7Wqh5O1oF1c1xOhnVSONh+BA=
+github.com/jrozner/weby v0.1.0/go.mod h1:cBLmTAkOScydeEd02pmDkSeQfdZUQ9Y3r3hcLSUZrqI=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=


### PR DESCRIPTION
Replace github.com/go-chi/chi/v5 with github.com/jrozner/weby throughout the backend. Weby wraps Go 1.22+ stdlib routing (http.ServeMux) and provides a global middleware stack.

Key changes:
- Entry points (bin/web, bin/api, bin/dev) and integration helpers now use weby.NewServeMux() with RequestID/WrapResponse/Logger middleware
- server.Web() and server.API() signatures changed from chi.Router to *http.ServeMux; inner authenticated routes wrapped with per-group middleware using handler chaining
- Route patterns updated to stdlib "METHOD /path" format; {type:regex} patterns simplified to {type} (handler already validates values)
- authschemes.AuthScheme.BindRoutes() changed from chi.Router to *http.ServeMux; all four auth scheme implementations updated
- dissectors.DissectedRequest.FromURL() now uses r.PathValue() instead of a chi url-param map; constructor signatures simplified accordingly
- Added middleware.InjectLogger() thin wrapper to inject request-scoped logger into context (used by logging.ReqLogger throughout services)
- Updated dissected_request_test.go to use r.SetPathValue() for URL param tests

<!--
Thank you for your interest in and contributing to ASHIRT! There
are a few simple things to check before submitting your pull request
that can help with the review process. We only seek to accept code that you are authorized to contribute to the project. This pull request template is included on our projects so that your contributions are made with the following confirmation: I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
-->

- Please review our [contributing guidelines](https://github.com/ashirt-ops/ashirt-server/blob/master/Contributing.md)
- Please review our [Code of Conduct](https://github.com/ashirt-ops/ashirt-server/blob/master/Code-of-Conduct.md)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
